### PR TITLE
Rename: API Browser -> API Documentation.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
         },
         {
           to: 'https://api.svix.com/docs',
-          label: 'API Browser',
+          label: 'API Documentation',
           position: 'left',
         },
         {

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,7 +12,7 @@ module.exports = {
     {
       type: 'link',
       href: 'https://api.svix.com/docs',
-      label: 'API Browser',
+      label: 'API Documentation',
     },
   ],
   consumersSidebar: [


### PR DESCRIPTION
What do you think? Should it be called "API Documentation" or "API Reference", or what?