### PR TITLE
Fix relative links on initial load

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -218,7 +218,7 @@ In the example above we showed how to send messages, though these messages were 
 
 Svix offers a pre-build management UI. With [one API call](https://api.svix.com/docs#operation/get_dashboard_access_api_v1_auth_dashboard_access__app_id___post), you can give your users access to this UI and they can then add their own endpoints themselves.
 
-More on that in the [management UI docs](management-ui).
+More on that in the [management UI docs](./management-ui.mdx).
 
 ### Using the API
 

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -5,7 +5,7 @@ title: How to Verify
 import CodeTabs from '@theme/CodeTabs';
 import TabItem from '@theme/TabItem';
 
-As shown in the [Why Verify section](./why), verifying incoming webhooks is very important. This section describes how to do it.
+As shown in the [Why Verify section](./why.mdx), verifying incoming webhooks is very important. This section describes how to do it.
 
 ## Verifying using our official libraries
 


### PR DESCRIPTION
On initial load, these links gets treated as relative to the current page, but once cached they load fine, this issue only occurs with production-built versions of the site (not when served from `yarn start`.