### PR TITLE
Fix img tag css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -47,7 +47,7 @@ html[data-theme="dark"] .menu a:not([href]).menu__link {
 }
 /* } */
 
-img {
+article img {
   border-radius: var(--ifm-global-radius);
   box-shadow: var(--ifm-global-shadow-lw);
 }


### PR DESCRIPTION
This should remove the box-shadow on the top-left logo 

![image](https://user-images.githubusercontent.com/84334931/134573522-09584c29-c893-455d-865d-23e23e0343de.png)
