### PR TITLE
Hide announcement bar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,6 +17,7 @@
   --ifm-code-font-size: 95%;
 
   --ifm-menu-link-padding-horizontal: 1rem;
+  --docusaurus-announcement-bar-height: 0 !important;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/84334931/135332092-634bbc5b-1fda-4b7b-b1bc-e0b2c57ac8b1.png)

After:
![image](https://user-images.githubusercontent.com/84334931/135332112-4924fae2-97a5-412d-94da-5f500143bc06.png)

There's a white box on the bottom of the sidebar.