### PR TITLE
add global site tag preset option in docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,6 +82,10 @@ module.exports = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
+        gtag: {
+          trackingID: "219524931",
+          anonymizeIP: true,
+        },
       },
     ],
   ],


### PR DESCRIPTION
Added the gtag preset for Google Analytics Global Site Tag in the docusarus.config.js file.

trackingID is the Google Analytics account ID.
anonymizeIP tells Google Analytics to anonymize users' IP addresses for privacy.