### PR TITLE
Update GA ID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,7 @@ module.exports = {
           customCss: require.resolve("./src/css/custom.css"),
         },
         gtag: {
-          trackingID: "219524931",
+          trackingID: "UA-219524931-1",
           anonymizeIP: true,
         },
       },


### PR DESCRIPTION
Updated the trackingID in the gtag preset in docusaurus.config.js as we weren't seeing pageviews being tracked in Google Analytics.