### PR TITLE
svix-react: Document AppPortal fullSize prop

### DIFF
--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -192,9 +192,11 @@ const App = () => <SvixEmbed />;
 ReactDOM.render(<App />, document.body);
 ```
 
+You can optionally use the `fullSize` prop (`<AppPortal fullSize />`) so that App Portal will automatically grow to fit its contents.
+
 ### Design Considerations
 
-When embedding the App Portal into your application, keep in mind that the App Portal is an information dense master-detail view. We recommend keeping the view at 100% width to avoid abbreviating important information for your users. If you are hoping to avoid having an embedded scrollbar, we recommend putting the view inside a full screen modal from your dashboard.
+When embedding the App Portal into your application, keep in mind that the App Portal is an information dense master-detail view. We recommend keeping the view at 100% width to avoid abbreviating important information for your users. If you are hoping to avoid having an embedded scrollbar, we recommend putting the view inside a full screen modal from your dashboard, or using the `fullSize` prop so that the App Portal sizes itself based on its content.
 
 ![embedded iframe modal](/img/app-portal/embedded-view-modal.png)
 


### PR DESCRIPTION
We recently began supporting a `fullSize` prop on `<AppPortal />` so that it grows to fit its contents. This PR just documents its existence.