### PR TITLE
Document environment-level setting for read-only Portals

### DIFF
--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -274,5 +274,5 @@ export default function ListEndpoints() {
 
 To get started and see a full list of hooks, refer to the [`svix-react` NPM package](https://www.npmjs.com/package/svix-react).
 
-## Read-only Consumer App Portals
-You can set all Consumer App Portals belonging to an environment to be read-only by enabling the Read-only toggle on the Environment Settings page.
+## Read Only Consumer App Portals
+You can set all Consumer App Portals belonging to an environment to be read only by enabling the Read Only toggle on the Environment Settings page.

--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -228,7 +228,7 @@ So for example:
 http://app.svix.com/login?primaryColor=28bb93&fontFamily=Roboto#key=eyJhcHBJZCI6ICJhcHBfMXRSdFlMN3pwWWR2NHFuWTRRZFI1azE4eXQ0IiwgInRva2VuIjogImFwcHNrX2UxOUN0Rm5hbTFoOU1Gamh5azRSMTUzNUNSd05VSWI0In0=
 ```
 
-# Implementing your own Consumer App Portal functionality
+## Implementing your own Consumer App Portal functionality
 You can implement Consumer App Portal functionality into your own dashboard using ergonomic React Hooks provided by the `svix-react` library. This approach allows you to use your own UI structure and components. The hooks are an abstraction over the `svix` JavaScript library and help to handle concerns like paginating over large lists of data, and reloading data.
 
 Using the hooks requires wrapping your application or components in `<SvixProvider />`:
@@ -273,3 +273,6 @@ export default function ListEndpoints() {
 ```
 
 To get started and see a full list of hooks, refer to the [`svix-react` NPM package](https://www.npmjs.com/package/svix-react).
+
+## Read-only Consumer App Portals
+You can set all Consumer App Portals belonging to an environment to be read-only by enabling the Read-only toggle on the Environment Settings page.


### PR DESCRIPTION
Adds documentation for the new environment-level read-only setting.

Also fixes a markdown formatting error for the React Hooks documentation.