### PR TITLE
Fix typo in Svix ngrok docs

### DIFF
--- a/docs/integrations/ngrok.mdx
+++ b/docs/integrations/ngrok.mdx
@@ -7,7 +7,7 @@ title: Using the ngrok Intergation
 In this tutorial, we will learn how to verify Svix webhook requests using ngrok both for local development and on ngrok Cloud Edge.
 
 :::info
-This tutorial assumes you are already familiar with the [Svix webhooks service](https://www.svix.com) and [ngrok][https://ngrok.com). If this is your first time using Svix,
+This tutorial assumes you are already familiar with the [Svix webhooks service](https://www.svix.com) and [ngrok](https://ngrok.com). If this is your first time using Svix,
 we recommend you first check out our [quickstart documentaion](https://docs.svix.com/overview). We also recommend checking out ngrok's documentation on [Webhook Verification](https://ngrok.com/docs/cloud-edge/modules/webhook).
 :::
 


### PR DESCRIPTION
Fixes a markdown typo causing the ngrok link to not render correctly.