### PR TITLE
typo: Update additional-authentication.mdx

### DIFF
--- a/docs/receiving/additional-authentication.mdx
+++ b/docs/receiving/additional-authentication.mdx
@@ -24,6 +24,6 @@ Svix supports setting custom headers to be sent for each endpoint both [using th
 
 ## Firewalls (IP blocking)
 
-Many, often larger, organizations have strict firewall rules for which IPs are allowed to send traffic to their systems. While this is not a very strong security mechanism on its own, it's often useful when used in conduction with other methods (such as webhook signatures).
+Many, often larger, organizations have strict firewall rules for which IPs are allowed to send traffic to their systems. While this is not a very strong security mechanism on its own, it's often useful when used in conjunction with other methods (such as webhook signatures).
 
 In order to support these organizations and their requirements, Svix only sends webhooks requests from a specific set of IPs as detailed in the [source IP addresses section](./source-ips.mdx).


### PR DESCRIPTION
fix typo in firewalls (ip blocking): conduction -> conjunction