### PR TITLE
Update app portal access and event type docs

### DIFF
--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -17,17 +17,14 @@ For more information on how to use the app portal please refer to the [receiving
 
 ## Giving your users access
 
-To give your users access to the [App Portal](./app-portal), just use the [dashboard access endpoint](https://api.svix.com/docs#operation/get_dashboard_access_api_v1_auth_dashboard_access__app_id___post). Calling this endpoint with an `app_id` returns a URL you can just redirect your users to in order to log them into the App Portal. They will stay logged in for a few days or until they log out.
+To give your users access to the [App Portal](./app-portal), just use the [dashboard access endpoint](https://api.svix.com/docs#tag/Authentication/operation/get_app_portal_access_api_v1_auth_app_portal_access__app_id___post). Calling this endpoint with an `app_id` returns a URL you can just redirect your users to in order to log them into the App Portal. They will stay logged in for a few days or until they log out.
 
 <CodeTabs>
 <TabItem value="js">
 
 ```js
 const svix = new Svix("AUTH_TOKEN");
-const dashboard = await svix.authentication.appPortalAccess(
-  "app_Xzx8bQeOB1D1XEYmAJaRGoj0",
-  {featureFlags: []}
-);
+const dashboard = await svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", {});
 // A URL that automatically logs user into the dashboard
 console.log(dashboard.url);
 ```
@@ -37,9 +34,7 @@ console.log(dashboard.url);
 
 ```python
 svix = Svix("AUTH_TOKEN")
-dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn{
-    feature_flags=[]
-})
+dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn())
 # A URL that automatically logs user into the dashboard
 print(dashboard.url)
 ```
@@ -49,9 +44,7 @@ print(dashboard.url)
 
 ```go
 svixClient := svix.New("AUTH_TOKEN", nil)
-dashboard, _ := svixClient.Authentication.AppPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.AppPortalAccessIn{
-    FeatureFlags: []string{}
-})
+dashboard, _ := svixClient.Authentication.AppPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.AppPortalAccessIn{})
 // A URL that automatically logs user into the dashboard
 fmt.Println(dashboard.Url)
 ```
@@ -63,9 +56,7 @@ fmt.Println(dashboard.Url)
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
 let dashboard = svix.authentication().app_portal_access(
     "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
-    AppPortalAccessIn {
-        feature_flags: Some(vec![])
-    }
+    AppPortalAccessIn { .. Default::default() }
 }).await?;
 // A URL that automatically logs user into the dashboard
 println!("{}", dashboard.url);
@@ -76,9 +67,7 @@ println!("{}", dashboard.url);
 
 ```java
 Svix svix = new Svix("AUTH_TOKEN");
-DashboardAccessOut dashboard = svix.getAuthentication().appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn()
-    .featureFlags(new String[]{})
-);
+AppPortalAccessOut dashboard = svix.getAuthentication().appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn());
 // A URL that automatically logs user into the dashboard
 System.out.println(dashboard.getUrl());
 ```
@@ -88,9 +77,7 @@ System.out.println(dashboard.getUrl());
 
 ```kotlin
 val svix = Svix("AUTH_TOKEN")
-val dashboard = svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn()
-    .featureFlags(arrayOf())
-)
+val dashboard = svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn())
 // A URL that automatically logs user into the dashboard
 println(dashboard.url)
 ```
@@ -100,9 +87,7 @@ println(dashboard.url)
 
 ```ruby
 svix = Svix::Client.new("AUTH_TOKEN")
-dashboard = svix.authentication.dashboard_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", Svix::AppPortalAccessIn::new({
-    "feature_flags": []
-}))
+dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", Svix::AppPortalAccessIn.new({}))
 # A URL that automatically logs user into the dashboard
 puts dashboard.url
 ```
@@ -112,9 +97,7 @@ puts dashboard.url
 
 ```csharp
 var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"));
-var dashboard = await svix.Authentication.AppPortalAccessAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn{
-    featureFlags: new string[] {}
-});
+var dashboard = await svix.Authentication.AppPortalAccessAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn{});
 // A URL that automatically logs user into the dashboard
 Console.WriteLine(dashboard.Url)
 ```
@@ -124,20 +107,18 @@ Console.WriteLine(dashboard.Url)
 
 ```shell
 export SVIX_AUTH_TOKEN="AUTH_TOKEN"
-svix authentication app-portal-access app_Xzx8bQeOB1D1XEYmAJaRGoj0 '{"featureFlags": []}'
+svix authentication app-portal app_Xzx8bQeOB1D1XEYmAJaRGoj0
 ```
 
 </TabItem>
 <TabItem value="curl">
 
 ```shell
-curl -X POST "https://api.svix.com/api/v1/auth/dashboard_access/app_Xzx8bQeOB1D1XEYmAJaRGoj0/" \
+curl -X POST "https://api.svix.com/api/v1/auth/app-portal-access/app_Xzx8bQeOB1D1XEYmAJaRGoj0/" \
     -H  "Accept: application/json" \
     -H  "Authorization:  Bearer AUTH_TOKEN" \
     -H 'Content-Type: application/json' \
-    -d '{
-        "featureFlags": []
-    }'
+    -d '{}'
 ```
 
 </TabItem>
@@ -189,7 +170,7 @@ npm install svix-react
 yarn add svix-react
 ```
 
-The npm package is lightweight and provides some basic styling and a loading indicator out of the box. To use it, simply provide the magic link from the [`get_dashboard_access` endpoint](https://api.svix.com/docs#operation/get_dashboard_access_api_v1_auth_dashboard_access__app_id___post).
+The npm package is lightweight and provides some basic styling and a loading indicator out of the box. To use it, simply provide the magic link from the [`app_portal_access` endpoint](https://api.svix.com/docs#tag/Authentication/operation/get_app_portal_access_api_v1_auth_app_portal_access__app_id___post).
 
 ```js
 import React from "react";
@@ -204,7 +185,7 @@ const SvixEmbed = () => {
   const [appPortal, setAppPortal] = React.useState(null);
   const svixAppPortal = React.useEffect(() => {
     // Prerequisite: You'll need an endpoint that returns the App Portal
-    // magic URL (https://api.svix.com/docs#operation/get_dashboard_access_api_v1_auth_dashboard_access__app_id___post)
+    // magic URL (https://api.svix.com/docs#tag/Authentication/operation/get_dashboard_access_api_v1_auth_dashboard_access__app_id___post)
     fetch(`/your-backend-service/svix/${svixAppId}/app-portal`, { method: "POST" })
       .then((res) => res.json())
       .then((result) => setAppPortal(result));

--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -24,8 +24,9 @@ To give your users access to the [App Portal](./app-portal), just use the [dashb
 
 ```js
 const svix = new Svix("AUTH_TOKEN");
-const dashboard = await svix.authentication.dashboardAccess(
-  "app_Xzx8bQeOB1D1XEYmAJaRGoj0"
+const dashboard = await svix.authentication.appPortalAccess(
+  "app_Xzx8bQeOB1D1XEYmAJaRGoj0",
+  {featureFlags: []}
 );
 // A URL that automatically logs user into the dashboard
 console.log(dashboard.url);
@@ -36,7 +37,9 @@ console.log(dashboard.url);
 
 ```python
 svix = Svix("AUTH_TOKEN")
-dashboard = svix.authentication.dashboard_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0")
+dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn{
+    feature_flags=[]
+})
 # A URL that automatically logs user into the dashboard
 print(dashboard.url)
 ```
@@ -46,7 +49,9 @@ print(dashboard.url)
 
 ```go
 svixClient := svix.New("AUTH_TOKEN", nil)
-dashboard, _ := svixClient.Authentication.DashboardAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0")
+dashboard, _ := svixClient.Authentication.AppPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.AppPortalAccessIn{
+    FeatureFlags: []string{}
+})
 // A URL that automatically logs user into the dashboard
 fmt.Println(dashboard.Url)
 ```
@@ -56,8 +61,11 @@ fmt.Println(dashboard.Url)
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let dashboard = svix.authentication().dashboard_access(
-    "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string()
+let dashboard = svix.authentication().app_portal_access(
+    "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+    AppPortalAccessIn {
+        feature_flags: Some(vec![])
+    }
 }).await?;
 // A URL that automatically logs user into the dashboard
 println!("{}", dashboard.url);
@@ -68,7 +76,9 @@ println!("{}", dashboard.url);
 
 ```java
 Svix svix = new Svix("AUTH_TOKEN");
-DashboardAccessOut dashboard = svix.getAuthentication().dashboardAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0");
+DashboardAccessOut dashboard = svix.getAuthentication().appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn()
+    .featureFlags(new String[]{})
+);
 // A URL that automatically logs user into the dashboard
 System.out.println(dashboard.getUrl());
 ```
@@ -78,7 +88,9 @@ System.out.println(dashboard.getUrl());
 
 ```kotlin
 val svix = Svix("AUTH_TOKEN")
-val dashboard = svix.authentication.dashboardAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0")
+val dashboard = svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn()
+    .featureFlags(arrayOf())
+)
 // A URL that automatically logs user into the dashboard
 println(dashboard.url)
 ```
@@ -88,7 +100,9 @@ println(dashboard.url)
 
 ```ruby
 svix = Svix::Client.new("AUTH_TOKEN")
-dashboard = svix.authentication.dashboard_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0")
+dashboard = svix.authentication.dashboard_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", Svix::AppPortalAccessIn::new({
+    "feature_flags": []
+}))
 # A URL that automatically logs user into the dashboard
 puts dashboard.url
 ```
@@ -98,7 +112,9 @@ puts dashboard.url
 
 ```csharp
 var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"));
-var dashboard = await svix.Authentication.DashboardAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0");
+var dashboard = await svix.Authentication.AppPortalAccessAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn{
+    featureFlags: new string[] {}
+});
 // A URL that automatically logs user into the dashboard
 Console.WriteLine(dashboard.Url)
 ```
@@ -108,7 +124,7 @@ Console.WriteLine(dashboard.Url)
 
 ```shell
 export SVIX_AUTH_TOKEN="AUTH_TOKEN"
-svix authentication dashboard app_Xzx8bQeOB1D1XEYmAJaRGoj0
+svix authentication app-portal-access app_Xzx8bQeOB1D1XEYmAJaRGoj0 '{"featureFlags": []}'
 ```
 
 </TabItem>
@@ -117,7 +133,11 @@ svix authentication dashboard app_Xzx8bQeOB1D1XEYmAJaRGoj0
 ```shell
 curl -X POST "https://api.svix.com/api/v1/auth/dashboard_access/app_Xzx8bQeOB1D1XEYmAJaRGoj0/" \
     -H  "Accept: application/json" \
-    -H  "Authorization:  Bearer AUTH_TOKEN"
+    -H  "Authorization:  Bearer AUTH_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "featureFlags": []
+    }'
 ```
 
 </TabItem>
@@ -130,6 +150,12 @@ https://app.svix.com/login?next=/endpoints/abc#key=xyz
 ```
 
 You should use a URL parsing library to add the query parameter (avoid editing the URL manually). Not all pages are supported.
+
+### Feature flags
+
+You may have noticed the empty set of "feature flags" being passed in the examples above. Feature flags can be used to restrict what event types your users will see in the Event Catalog and the API.
+
+To learn more refer to the [Event Types](./event-types.mdx#event-type-feature-flags) documentation.
 
 ## Embedding in your own dashboard
 

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -442,3 +442,157 @@ Enabling this setting will cause your event types to be statically served on **s
 ### What it looks like
 
 ![event-catalog-published](./img/event-catalog-published.png)
+
+## Event type feature flags
+
+When introducing new features in your application it can be useful to only expose them to a select set of users.
+
+Event types can be hidden from users by setting a feature flag on them. If a feature flag is set on an event type users won't see the event type in the Event Catalog and the API, unless they have an authorization token that explicitly allows them.
+
+A feature flag is an arbitrary string that you can set at event type creation time. You can also remove or add back the feature flag by updating an existing event type. Feature flags follow the same naming rules as the event type name itself: `^[a-zA-Z0-9\\-_.]+$`.
+
+Here's how you can create an event type with a feature flag:
+
+<CodeTabs>
+<TabItem value="js">
+
+```js
+import { Svix } from "svix";
+
+const svix = new Svix("AUTH_TOKEN");
+const eventType = await svix.eventType.create({
+  name: "user.signup",
+  description: "A user has signed up",
+  featureFlag: "user-signups",
+});
+```
+
+</TabItem>
+<TabItem value="py">
+
+```python
+from svix.api import Svix, EventTypeIn
+
+svix = Svix("AUTH_TOKEN")
+app = svix.event_type.create(EventTypeIn(
+    name="user.signup",
+    description="A user has signed up",
+    feature_flag="user-signups"
+))
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	svix "github.com/svix/svix-webhooks/go"
+)
+
+svixClient := svix.New("AUTH_TOKEN", nil)
+app, err := svixClient.EventType.Create(&svix.EventTypeIn{
+    Name: "user.signup",
+    Description: "A user has signed up",
+    FeatureFlag: svix.NullableStrig("user-signups"),
+})}
+```
+
+</TabItem>
+<TabItem value="rust">
+
+```rust
+use svix::api::{ApplicationIn, Svix, SvixOptions};
+
+let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let event_type = svix.event_type().create(EventTypeIn {
+    name: "user.signup".to_string(),
+    description: "A user has signed up".to_string(),
+    feature_flag: Some("user-signups".to_string()),
+    ..EventTypeIn::default()
+}).await?;
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+import com.svix.Svix;
+import com.svix.models.EventTypeIn;
+
+
+Svix svix = new Svix("AUTH_TOKEN");
+svix.getEventType()
+  .create(new EventTypeIn()
+    .name("user.signup")
+    .description("A user has signed up")
+    .featureFlag("user-signups")
+  );
+```
+
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+import com.svix.kotlin.Svix;
+import com.svix.kotlin.models.EventTypeIn;
+
+val svix = Svix("AUTH_TOKEN");
+svix.eventType.create(
+                EventTypeIn(
+                    name = "user.signup",
+                    description = "A user has signed up",
+                    featureFlag = "user-signups",
+                ));
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+svix = Svix::Client.new("AUTH_TOKEN")
+svix.event_type.create(Svix::EventTypeIn.new({
+        "name" => "user.signup",
+        "description" => "A user has signed up",
+        "feature_flag": "user-signups"}))
+```
+
+</TabItem>
+<TabItem value="csharp">
+
+```csharp
+var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"));
+await svix.EventType.CreateAsync(new EventTypeIn(
+    name: "user.signup",
+    description: "A user has signed up",
+    featureFlag: "user-signups"
+))
+```
+
+</TabItem>
+<TabItem value="cli">
+
+```shell
+export SVIX_AUTH_TOKEN='AUTH_TOKEN'
+svix event-type create '{ "name": "user.signup", "description": "A user has signed up", "featureFlag": "user-signups" }'
+```
+
+</TabItem>
+<TabItem value="curl">
+
+```shell
+export SVIX_AUTH_TOKEN='AUTH_TOKEN'
+
+curl -X POST "https://api.svix.com/api/v1/event-type/" \
+    -H  "Accept: application/json" \
+    -H  "Content-Type: application/json" \
+    -H  "Authorization: Bearer ${SVIX_AUTH_TOKEN}" \
+    -d '{ "name": "user.signup", "description": "A user has signed up", "featureFlag": "user-signups" }'
+```
+
+</TabItem>
+</CodeTabs>
+
+:::caution
+Keep in mind that endpoints with no event type filtering will receive all messages regardless of feature flags. Also, users with knowledge of a feature flag-gated event type can subscribe to that event type regardless of feature flags.
+Feature flags only impact event types' visibility in the catalog and the API, not their deliverability.
+:::

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -592,7 +592,235 @@ curl -X POST "https://api.svix.com/api/v1/event-type/" \
 </TabItem>
 </CodeTabs>
 
-:::caution
+If a user tries to retrieve this newly created event type they will get a not-found error. To give them access you need to give them an access token that explicity allows them to see event types with the feature flag set during creation.
+
+<CodeTabs>
+<TabItem value="js">
+
+```js
+const svix = new Svix("AUTH_TOKEN");
+const dashboard = await svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", {
+    featureFlags: ["user-signups"]
+});
+// A URL that automatically logs user into the dashboard
+console.log(dashboard.url);
+```
+
+</TabItem>
+<TabItem value="py">
+
+```python
+svix = Svix("AUTH_TOKEN")
+dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn(
+    feature_flags=["user-signups"]
+))
+# A URL that automatically logs user into the dashboard
+print(dashboard.url)
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+svixClient := svix.New("AUTH_TOKEN", nil)
+dashboard, _ := svixClient.Authentication.AppPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.AppPortalAccessIn{
+    FeatureFlags: []string{"user-signups"}
+})
+// A URL that automatically logs user into the dashboard
+fmt.Println(dashboard.Url)
+```
+
+</TabItem>
+<TabItem value="rust">
+
+```rust
+let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let dashboard = svix.authentication().app_portal_access(
+    "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+    AppPortalAccessIn { 
+        feature_flags: Some(vec!["user-signups".to_string()]),
+        .. Default::default() 
+    }
+}).await?;
+// A URL that automatically logs user into the dashboard
+println!("{}", dashboard.url);
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+Svix svix = new Svix("AUTH_TOKEN");
+AppPortalAccessOut dashboard = svix.getAuthentication().appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn()
+    .featureFlags(new String[]{"user-signups"})
+);
+// A URL that automatically logs user into the dashboard
+System.out.println(dashboard.getUrl());
+```
+
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+val svix = Svix("AUTH_TOKEN")
+val dashboard = svix.authentication.appPortalAccess("app_Xzx8bQeOB1D1XEYmAJaRGoj0", AppPortalAccessIn()
+    .featureFlags(arrayOf("user-signups"))
+)
+// A URL that automatically logs user into the dashboard
+println(dashboard.url)
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+svix = Svix::Client.new("AUTH_TOKEN")
+dashboard = svix.authentication.app_portal_access("app_Xzx8bQeOB1D1XEYmAJaRGoj0", Svix::AppPortalAccessIn.new({
+    "feature_flags": ["user-signups"]
+}))
+# A URL that automatically logs user into the dashboard
+puts dashboard.url
+```
+
+</TabItem>
+<TabItem value="csharp">
+
+```csharp
+var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"));
+var dashboard = await svix.Authentication.AppPortalAccessAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new AppPortalAccessIn{
+    featureFlags: new string[] {"user-signups"}
+});
+// A URL that automatically logs user into the dashboard
+Console.WriteLine(dashboard.Url)
+```
+
+</TabItem>
+<TabItem value="cli">
+
+```shell
+export SVIX_AUTH_TOKEN="AUTH_TOKEN"
+svix authentication app-portal app_Xzx8bQeOB1D1XEYmAJaRGoj0 '{
+    "featureFlags": ["user-signups"]
+}'
+```
+
+</TabItem>
+<TabItem value="curl">
+
+```shell
+curl -X POST "https://api.svix.com/api/v1/auth/app-portal-access/app_Xzx8bQeOB1D1XEYmAJaRGoj0/" \
+    -H  "Accept: application/json" \
+    -H  "Authorization:  Bearer AUTH_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{"featureFlags": ["user-signups"]}'
+```
+
+</TabItem>
+</CodeTabs>
+
+A user with this newly minted dashboard access token will be able to see this new event type.
+
+Once you're ready to release this new event type to all of your users simply remove the feature flag from it.
+
+<CodeTabs>
+<TabItem value="js">
+
+```js
+const svix = new Svix("AUTH_TOKEN");
+await svix.eventType.update("user.signup", { featureFlag: null });
+```
+
+</TabItem>
+<TabItem value="py">
+
+```python
+svix = Svix("AUTH_TOKEN")
+svix.event_type.update("user.signup", EventTypeUpdate(feature_flag=None))
+```
+
+</TabItem>
+<TabItem value="go">
+
+```go
+svixClient := svix.New("AUTH_TOKEN", nil)
+eventTypeOut, _ := svixClient.EventType.Update("user.signup", &svix.EventTypeUpdate{ FeatureFlag: nil })
+```
+
+</TabItem>
+<TabItem value="rust">
+
+```rust
+let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let event_type_out = svix.event_type().update(
+    "user.signup".to_string(),
+    EventTypeUpdate { 
+        feature_flag: None,
+        .. Default::default() 
+    }
+}).await?;
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+Svix svix = new Svix("AUTH_TOKEN");
+EventTypeOut eventTypeOut = svix.getEventType().update("user.signup", new EventTypeUpdate()
+    .featureFlag(null)
+);
+```
+
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+val svix = Svix("AUTH_TOKEN")
+val eventTypeOut = svix.eventType.update("user.signup", EventTypeUpdate().featureFlag(null))
+```
+
+</TabItem>
+<TabItem value="ruby">
+
+```ruby
+svix = Svix::Client.new("AUTH_TOKEN")
+event_type_out = svix.event_type.update("user.signup", Svix::EventTypeUpdate.new({
+    "feature_flag": nil
+}))
+```
+
+</TabItem>
+<TabItem value="csharp">
+
+```csharp
+var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"));
+var eventTypeOut = await svix.EventType.Update("user.signup", new EventTypeUpdate{
+    featureFlag: null
+});
+```
+
+</TabItem>
+<TabItem value="cli">
+
+```shell
+export SVIX_AUTH_TOKEN="AUTH_TOKEN"
+svix event-type update user.signup '{"featureFlag": null}'
+```
+
+</TabItem>
+<TabItem value="curl">
+
+```shell
+curl -X POST "https://api.svix.com/api/v1/event-type/user.signup/" \
+    -H  "Accept: application/json" \
+    -H  "Authorization:  Bearer AUTH_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{"featureFlag": null}'
+```
+
+</TabItem>
+</CodeTabs>
+
+:::info Important
 Keep in mind that endpoints with no event type filtering will receive all messages regardless of feature flags. Also, users with knowledge of a feature flag-gated event type can subscribe to that event type regardless of feature flags.
 Feature flags only impact event types' visibility in the catalog and the API, not their deliverability.
 :::


### PR DESCRIPTION
App portal access code examples use the new `app-portal-access` method. Event type docs introduce feature flags.