### PR TITLE
fix homebrew link

### DIFF
--- a/docs/tutorials/cli.mdx
+++ b/docs/tutorials/cli.mdx
@@ -23,7 +23,7 @@ Before you go any further, you need to [install the Svix CLI](https://github.com
 <CLITabs>
 <TabItem value="homebrew">
 
-To install the Svix CLI with [Homebrew](https://homebrew.sh), run:
+To install the Svix CLI with [Homebrew](https://brew.sh), run:
 
 
 


### PR DESCRIPTION
We were linking to homebrew.sh instead of brew.sh