### PR TITLE
rename "incoming webhooks" to "operational webhooks"

### DIFF
--- a/docs/common-usage-examples.mdx
+++ b/docs/common-usage-examples.mdx
@@ -50,7 +50,7 @@ For more information, please refer to the [idempotency section of the docs](./id
 
 As you may expect from a webhooks service, Svix also uses webhooks to notify you of events. For example, Svix will send you a webhook when a message delivery has failed, or an endpoint has been failing for too long of a period.
 
-For more information, please refer to the [incoming webhooks section of the docs](./incoming-webhooks.mdx).
+For more information, please refer to the [operational webhooks section of the docs](./incoming-webhooks.mdx).
 
 
 ### Environments (sub-accounts)

--- a/docs/incoming-webhooks.mdx
+++ b/docs/incoming-webhooks.mdx
@@ -1,12 +1,12 @@
 ---
-title: Incoming Webhooks
+title: Operational Webhooks
 ---
 
 import EventTypeTabs from '@theme/EventTypeTags';
 import TabItem from '@theme/TabItem';
 
 
-As you may expect from a webhooks service, Svix also uses webhooks to notify you of events. To configure which event types you would like to listen to and which endpoints these events will be sent to, please use the [Incoming Webhooks](https://dashboard.svix.com/webhooks) section of the dashboard.
+As you may expect from a webhooks service, Svix also uses webhooks to notify you of events. To configure which event types you would like to listen to and which endpoints these events will be sent to, please use the [Operational Webhooks](https://dashboard.svix.com/webhooks) section of the dashboard.
 
 
 ## Messages we send

--- a/docs/play.mdx
+++ b/docs/play.mdx
@@ -2,7 +2,7 @@
 title: Svix Play - webhook debugger
 ---
 
-You can use the [Svix Play webhook playground and debugger](https://www.svix.com/play/) to easily inspect, test and debug incoming webhooks.
+You can use the [Svix Play webhook playground and debugger](https://www.svix.com/play/) to easily inspect, test and debug operational webhooks.
 
 It's a very useful tool for anyone developing webhooks - for both senders and consumers. More so, it's available to everyone for free, not just users of Svix!
 

--- a/docs/receiving/using-app-portal/adding-endpoints.mdx
+++ b/docs/receiving/using-app-portal/adding-endpoints.mdx
@@ -14,7 +14,7 @@ listen to.
 If you don't have a URL or your service isn't quite ready to start receiving events just yet,
 just press the **use Svix Play** button to have a unique URL generated for you.
 
-You'll be able to view and inspect all incoming webhooks sent to your Svix Play URL, making it
+You'll be able to view and inspect all operational webhooks sent to your Svix Play URL, making it
 effortless to get started.
 :::
 

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -5,7 +5,7 @@ title: How to Verify Webhooks with the Svix Libraries
 import CodeTabs from '@theme/CodeTabs';
 import TabItem from '@theme/TabItem';
 
-As shown in the [Why Verify section](./why.mdx), verifying incoming webhooks is very important. This section describes how to do it.
+As shown in the [Why Verify section](./why.mdx), verifying operational webhooks is very important. This section describes how to do it.
 
 ## Verifying using our official libraries
 


### PR DESCRIPTION
Pretty much a straight find/replace.

~~Seems like we should have a redirect from the old `incoming-webhooks` url to the new `operational-webhooks` url, but I'm not sure if this should be done here, janky style, via a meta refresh (or similar). Might be better for SEO to handle the redirect as a proper 301 in whatever webserver is serving the static files.~~

Leaving the old `/incoming-webhooks` URL where it is for now.