### PR TITLE
Fix typo in event-types doc page

### DIFF
--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -436,7 +436,7 @@ done < data.csv
 
 By default, your event types are only accessible to users from within an authenticated session on the Application Portal.
 
-If you would like to have them publicly accessible, you can enable the "Make Publish" setting from the Event Catalog configuration screen in the Dashboard settings.
+If you would like to have them publicly accessible, you can enable the "Make Public" setting from the Event Catalog configuration screen in the Dashboard settings.
 
 Enabling this setting will cause your event types to be statically served on **svix.com**. You can link or embed that site within your own documentation.
 


### PR DESCRIPTION
Was going over the docs and noticed this one. "Make Publish" should be "Make Public".

<img width="798" alt="Screenshot 2023-05-11 at 8 56 02 PM" src="https://github.com/svix/svix-docs/assets/133019767/7d7ff7a8-2621-4001-8c1f-eea705d076d7">
