### PR TITLE
Add Rust example for bulk upload event types

### DIFF
--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -298,34 +298,39 @@ func main() {
 
 ```rust
 use std::{error::Error, fs::File};
-use svix::api::{Svix, EventTypeIn};
+use svix::api::{EventTypeIn, Svix};
 use tokio::runtime::Builder;
 
 async fn execute() -> Result<(), Box<dyn Error>> {
-    let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+    let svix = Svix::new(
+        "testsk_nZUt5v1TfS-TXc0nfKq1EuDH6Vf09kPj.eu".to_string(),
+        None,
+    );
 
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b'|')
-        .from_reader(File::open("./data.csv")?);
+        .from_reader(File::open("src/data.csv")?);
 
     for result in reader.records() {
         let record = result?;
-        
-        svix.event_type().create(EventTypeIn { 
-            name: record[0].to_string(), 
-            description: record[1].to_string(), 
-            ..EventTypeIn::default()
-        }, None).await?;
+
+        svix.event_type()
+            .create(
+                EventTypeIn {
+                    name: record[0].to_string(),
+                    description: record[1].to_string(),
+                    ..EventTypeIn::default()
+                },
+                None,
+            )
+            .await?;
     }
 
     Ok(())
 }
 
 fn main() {
-    let rt = Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
 
     rt.block_on(execute());
 }

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -297,8 +297,38 @@ func main() {
 <TabItem value="rust">
 
 ```rust
-// Example TBD
-// Read the CSV and create event types
+use std::{error::Error, fs::File};
+use svix::api::{Svix, EventTypeIn};
+use tokio::runtime::Builder;
+
+async fn execute() -> Result<(), Box<dyn Error>> {
+    let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(b'|')
+        .from_reader(File::open("./data.csv")?);
+
+    for result in reader.records() {
+        let record = result?;
+        
+        svix.event_type().create(EventTypeIn { 
+            name: record[0].to_string(), 
+            description: record[1].to_string(), 
+            ..EventTypeIn::default()
+        }, None).await?;
+    }
+
+    Ok(())
+}
+
+fn main() {
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(execute());
+}
 ```
 
 </TabItem>

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -299,7 +299,6 @@ func main() {
 ```rust
 use std::{error::Error, fs::File};
 use svix::api::{EventTypeIn, Svix};
-use tokio::runtime::Builder;
 
 async fn execute() -> Result<(), Box<dyn Error>> {
     let svix = Svix::new(
@@ -329,10 +328,9 @@ async fn execute() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn main() {
-    let rt = Builder::new_current_thread().enable_all().build().unwrap();
-
-    rt.block_on(execute());
+#[tokio::main]
+async fn main() {
+    execute().await.unwrap();
 }
 ```
 

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -303,7 +303,7 @@ use tokio::runtime::Builder;
 
 async fn execute() -> Result<(), Box<dyn Error>> {
     let svix = Svix::new(
-        "testsk_nZUt5v1TfS-TXc0nfKq1EuDH6Vf09kPj.eu".to_string(),
+        "AUTH_TOKEN".to_string(),
         None,
     );
 


### PR DESCRIPTION
We had a 'TBD' that was visible to customers so I added the code. I tested the example in my machine to make sure it actually works.

**Before**
<img width="912" alt="Screenshot 2023-06-23 at 3 51 56 PM" src="https://github.com/svix/svix-docs/assets/133019767/ebfdc9dd-486c-4668-873a-0dadbe378843">

**After**

<img width="900" alt="Screenshot 2023-06-23 at 3 56 13 PM" src="https://github.com/svix/svix-docs/assets/133019767/346ddb15-10b6-4af3-99cf-3e5d253304f1">
