### PR TITLE
Quickstart: add webhook `type` to the example payloads

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -328,10 +328,10 @@ curl -X POST "https://api.svix.com/api/v1/app/app_Xzx8bQeOB1D1XEYmAJaRGoj0/msg/"
 
 #### Including the event type in the payload
 
-Webhook consumers often consume to multiple event types using the same endpoint. To enable them to be able to differentiate different events, it's common practice to include the event type in the webhook's payload.
+Webhook consumers often consume multiple event types using the same endpoint. To enable them to be able to differentiate different events, it's common practice to include the event type in the webhook's payload.
 Svix, however, doesn't automatically inject the event type into the payload, in order to give our customers full control over the content and structure of the payloads they send.
 
-Most commonly people include the event type in the payload as a top-level key called `type`, `event_type`, or `eventType`, but it's up to you how you wan tto call it.
+Most commonly people include the event type in the payload as a top-level key called `type`, `event_type`, or `eventType`, but it's up to you how you want to call it.
 
 #### Idempotentcy
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -171,6 +171,7 @@ await svix.message.create("app_Xzx8bQeOB1D1XEYmAJaRGoj0", {
   eventType: "invoice.paid",
   eventId: "evt_Wqb1k73rXprtTm7Qdlr38G",
   payload: {
+    type: "invoice.paid",
     id: "invoice_WF7WtCLFFtd8ubcTgboSFNql",
     status: "paid",
     attempt: 2,
@@ -189,6 +190,7 @@ svix.message.create(
         event_type="invoice.paid",
         event_id="evt_Wqb1k73rXprtTm7Qdlr38G",
         payload={
+            "type": "invoice.paid",
             "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
             "status": "paid",
             "attempt": 2
@@ -206,6 +208,7 @@ svixClient.Message.Create("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.MessageIn{
     EventType: "invoice.paid",
     EventId:   svix.NullableString("evt_Wqb1k73rXprtTm7Qdlr38G"),
     Payload: map[string]interface{}{
+        "type":    "invoice.paid",
         "id":      "invoice_WF7WtCLFFtd8ubcTgboSFNql",
         "status":  "paid",
         "attempt": 2,
@@ -223,6 +226,7 @@ svix.message().create("app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
         event_type: "invoice.paid".to_string(),
         event_id: "evt_Wqb1k73rXprtTm7Qdlr38G".to_string(),
         payload: json!({
+            "type": "invoice.paid",
             "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
             "status": "paid",
             "attempt": 2
@@ -242,6 +246,7 @@ svix.getMessage().create("app_Xzx8bQeOB1D1XEYmAJaRGoj0",
     .eventType("invoice.paid")
     .eventId("evt_Wqb1k73rXprtTm7Qdlr38G")
     .payload("{" +
+       "\"type\": \"invoice.paid\"," +
        "\"id\": \"invoice_WF7WtCLFFtd8ubcTgboSFNql\"," +
        "\"status\":  \"paid\"," +
        "\"attempt\": 2" +
@@ -257,6 +262,7 @@ svix.message.create("app_Xzx8bQeOB1D1XEYmAJaRGoj0",
         MessageIn(
             eventType = "invoice.paid",
             payload = mapOf<String, Any>(
+                "type": "invoice.paid",
                 "id" to "invoice_WF7WtCLFFtd8ubcTgboSFNql",
                 "status" to "paid",
                 "attempt" to 2
@@ -273,6 +279,7 @@ svix.message.create("app_Xzx8bQeOB1D1XEYmAJaRGoj0",
     Svix::MessageIn.new({
         "event_type" => "invoice.paid",
         "payload" => {
+            "type": "invoice.paid",
             "id" => "invoice_WF7WtCLFFtd8ubcTgboSFNql",
             "status" => "paid",
             "attempt" => 2
@@ -288,6 +295,7 @@ var svix = new SvixClient("AUTH_TOKEN", new SvixOptions("https://api.svix.com"))
 await svix.Message.CreateAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new MessageIn(
     eventType: "invoice.paid",
     payload: new {
+        type: "invoice.paid",
         id = "invoice_WF7WtCLFFtd8ubcTgboSFNql",
         status = "paid",
         attempt = 2
@@ -301,7 +309,7 @@ await svix.Message.CreateAsync("app_Xzx8bQeOB1D1XEYmAJaRGoj0", new MessageIn(
 
 ```shell
 export SVIX_AUTH_TOKEN="AUTH_TOKEN"
-svix message create app_Xzx8bQeOB1D1XEYmAJaRGoj0 '{ "eventType": "invoice.paid", "eventId": "evt_Wqb1k73rXprtTm7Qdlr38G", "payload": { "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql", "status": "paid", "attempt": 2 } }'
+svix message create app_Xzx8bQeOB1D1XEYmAJaRGoj0 '{ "eventType": "invoice.paid", "eventId": "evt_Wqb1k73rXprtTm7Qdlr38G", "payload": { "type": "event.type", "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql", "status": "paid", "attempt": 2 } }'
 ```
 
 </TabItem>
@@ -312,11 +320,18 @@ curl -X POST "https://api.svix.com/api/v1/app/app_Xzx8bQeOB1D1XEYmAJaRGoj0/msg/"
     -H  "Accept: application/json" \
     -H  "Content-Type: application/json" \
     -H  "Authorization: Bearer AUTH_TOKEN" \
-    -d '{"eventType": "invoice.paid", "eventId": "evt_Wqb1k73rXprtTm7Qdlr38G", "payload": {"id": "invoice_WF7WtCLFFtd8ubcTgboSFNql", "status": "paid", "attempt": 2}}'
+    -d '{"eventType": "invoice.paid", "eventId": "evt_Wqb1k73rXprtTm7Qdlr38G", "payload": {"type": "event.type", "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql", "status": "paid", "attempt": 2}}'
 ```
 
 </TabItem>
 </CodeTabs>
+
+#### Including the event type in the payload
+
+Webhook consumers often consume to multiple event types using the same endpoint. To enable them to be able to differentiate different events, it's common practice to include the event type in the webhook's payload.
+Svix, however, doesn't automatically inject the event type into the payload, in order to give our customers full control over the content and structure of the payloads they send.
+
+Most commonly people include the event type in the payload as a top-level key called `type`, `event_type`, or `eventType`, but it's up to you how you wan tto call it.
 
 #### Idempotentcy
 


### PR DESCRIPTION
Because the examples lacked this type, people were mistakenly led to believe that they don't need to include the type in the payload.

Fixes #125