### PR TITLE
Docs: repair types, syntax, formatting of rust examples

### DIFF
--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -58,10 +58,14 @@ fmt.Println(dashboard.Url)
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let dashboard = svix.authentication().app_portal_access(
-    "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
-    AppPortalAccessIn { .. Default::default() }
-}).await?;
+let dashboard = svix
+    .authentication()
+    .app_portal_access(
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        AppPortalAccessIn::default(),
+        None,
+    )
+    .await?;
 // A URL that automatically logs user into the dashboard
 println!("{}", dashboard.url);
 ```

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -82,14 +82,18 @@ app, err := svixClient.EventType.Create(&svix.EventTypeIn{
 <TabItem value="rust">
 
 ```rust
-use svix::api::{ApplicationIn, Svix, SvixOptions};
-
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let event_type = svix.event_type().create(EventTypeIn {
-    name: "user.signup".to_string(),
-    description: "A user has signed up".to_string(),
-    ..EventTypeIn::default()
-}).await?;
+ let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+ let event_type = svix
+     .event_type()
+     .create(
+         EventTypeIn {
+             name: "user.signup".to_string(),
+             description: "A user has signed up".to_str
+             ..EventTypeIn::default()
+         },
+         None,
+     )
+     .await?;
 ```
 
 </TabItem>
@@ -301,10 +305,7 @@ use std::{error::Error, fs::File};
 use svix::api::{EventTypeIn, Svix};
 
 async fn execute() -> Result<(), Box<dyn Error>> {
-    let svix = Svix::new(
-        "AUTH_TOKEN".to_string(),
-        None,
-    );
+    let svix = Svix::new("AUTH_TOKEN".to_string(), None);
 
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b'|')
@@ -592,12 +593,18 @@ app, err := svixClient.EventType.Create(&svix.EventTypeIn{
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let event_type = svix.event_type().create(EventTypeIn {
-    name: "user.signup".to_string(),
-    description: "A user has signed up".to_string(),
-    feature_flag: Some("beta-feature-a".to_string()),
-    ..EventTypeIn::default()
-}).await?;
+let event_type = svix
+    .event_type()
+    .create(
+        EventTypeIn {
+            name: "user.signup".to_string(),
+            description: "A user has signed up".to_string(),
+            feature_flag: Some("beta-feature-a".to_string()),
+            ..EventTypeIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>
@@ -723,13 +730,17 @@ fmt.Println(dashboard.Url)
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let dashboard = svix.authentication().app_portal_access(
-    "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
-    AppPortalAccessIn { 
-        feature_flags: Some(vec!["beta-feature-a".to_string()]),
-        .. Default::default() 
-    }
-}).await?;
+let dashboard = svix
+    .authentication()
+    .app_portal_access(
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        AppPortalAccessIn {
+            feature_flags: Some(vec!["beta-feature-a".to_string()]),
+            ..Default::default()
+        },
+        None,
+    )
+    .await?;
 // A URL that automatically logs user into the dashboard
 println!("{}", dashboard.url);
 ```
@@ -839,13 +850,17 @@ eventTypeOut, _ := svixClient.EventType.Update("user.signup", &svix.EventTypeUpd
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let event_type_out = svix.event_type().update(
-    "user.signup".to_string(),
-    EventTypeUpdate { 
-        feature_flag: None,
-        .. Default::default() 
-    }
-}).await?;
+let event_type_out = svix
+    .event_type()
+    .update(
+        "user.signup".to_string(),
+        EventTypeUpdate {
+            feature_flag: None,
+            ..Default::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -78,10 +78,16 @@ app, err := svixClient.Application.Create(&svix.ApplicationIn{
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let app = svix.application().create(ApplicationIn {
-    name: "Application name".to_string(),
-    ..ApplicationIn::default()
-}).await?;
+let app = svix
+    .application()
+    .create(
+        ApplicationIn {
+            name: "Application name".to_string(),
+            ..ApplicationIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>
@@ -221,19 +227,23 @@ svixClient.Message.Create("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.MessageIn{
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-svix.message().create("app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
-    MessageIn {
-        event_type: "invoice.paid".to_string(),
-        event_id: "evt_Wqb1k73rXprtTm7Qdlr38G".to_string(),
-        payload: json!({
-            "type": "invoice.paid",
-            "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
-            "status": "paid",
-            "attempt": 2
-        }),
-        ..MessageIn::default()
-    }
-).await?;
+svix.message()
+    .create(
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        MessageIn {
+            event_type: "invoice.paid".to_string(),
+            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_string()),
+            payload: json!({
+                "type": "invoice.paid",
+                "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
+                "status": "paid",
+                "attempt": 2
+            }),
+            ..MessageIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>
@@ -407,12 +417,18 @@ svixClient.Endpoint.Create("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.EndpointIn{
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-svix.endpoint().create(EndpointIn {
-    url: "https://api.example.com/svix-webhooks/".to_string(),
-    version: 1,
-    description: "My main endpoint".to_string(),
-    ..EndpointIn::default()
-}).await?;
+svix.endpoint()
+    .create(
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        EndpointIn {
+            url: "https://api.example.com/svix-webhooks/".to_string(),
+            version: 1,
+            description: Some("My main endpoint".to_string()),
+            ..EndpointIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>

--- a/docs/rate-limit.mdx
+++ b/docs/rate-limit.mdx
@@ -70,11 +70,17 @@ app, err := svixClient.Application.Create(&svix.ApplicationIn{
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let app = svix.application().create(ApplicationIn {
-    name: "Application name".to_string(),
-    rate_limit: 1000,
-    ..ApplicationIn::default()
-}).await?;
+let app = svix
+    .application()
+    .create(
+        ApplicationIn {
+            name: "Application name".to_string(),
+            rate_limit: Some(1000),
+            ..ApplicationIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -222,11 +222,14 @@ let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw".to_string();
 let mut headers = http::header::HeaderMap::new();
 headers.insert("svix-id", "msg_p5jXN8AQM9LWM0D4loKWxJek");
 headers.insert("svix-timestamp", "1614265330");
-headers.insert("svix-signature", "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=");
+headers.insert(
+    "svix-signature",
+    "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=",
+);
 
 let payload = b"{\"test\": 2432232314}";
 
-let wh = Webhook::new(secret)?;
+let wh = Webhook::new(&secret)?;
 wh.verify(&payload, &headers)?;
 // returns Ok on success, Err otherwise
 ```
@@ -669,10 +672,7 @@ use hyper::HeaderMap;
 
 pub const SECRET: &'static str = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
 
-pub async fn webhook_in(
-    headers: HeaderMap,
-    body: Bytes,
-) -> StatusCode {
+pub async fn webhook_in(headers: HeaderMap, body: Bytes) -> StatusCode {
     let wh = svix::webhooks::Webhook::new(SECRET);
     if let Err(_) = wh {
         return StatusCode::INTERNAL_SERVER_ERROR;
@@ -686,8 +686,6 @@ pub async fn webhook_in(
 
     StatusCode::NO_CONTENT
 }
-
-
 ```
 
 ### Ruby (Ruby on Rails)

--- a/docs/retention.md
+++ b/docs/retention.md
@@ -74,18 +74,22 @@ svixClient.Message.Create("app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.MessageIn{
 
 ```rust
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-svix.message().create("app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
-    MessageIn {
-        event_type: "invoice.paid".to_string(),
-        event_id: "evt_Wqb1k73rXprtTm7Qdlr38G".to_string(),
-        payload: json!({
-            "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
-            "status": "paid",
-            "attempt": 2
-        }),
-        ..MessageIn::default()
-    }
-).await?;
+svix.message()
+    .create(
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        MessageIn {
+            event_type: "invoice.paid".to_string(),
+            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_string()),
+            payload: json!({
+                "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
+                "status": "paid",
+                "attempt": 2
+            }),
+            ..MessageIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -173,10 +173,16 @@ app, err := svixClient.Application.Create(&svix.ApplicationIn{
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
-let app = svix.application().create(ApplicationIn {
-    name: "Application name".to_string(),
-    ..ApplicationIn::default()
-}).await?;
+let app = svix
+    .application()
+    .create(
+        ApplicationIn {
+            name: "Application name".to_string(),
+            ..ApplicationIn::default()
+        },
+        None,
+    )
+    .await?;
 ```
 
 </TabItem>


### PR DESCRIPTION
Added missing parameters, changed incorrect types, removed erroneous braces, and passed everything through rustfmt on default settings.