### PR TITLE
App Portal: update documentation about primaryColor for light and dark modes

### DIFF
--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -233,7 +233,7 @@ Please use proper URL parsing rather than string manipulation as the structure o
 
 The supported parameters are:
 
-- `primaryColor` - the primary color of the UI. Format: `RRGGBB`, e.g. `28bb93`.
+- `primaryColorLight` and `primaryColorDark` - the primary color of the UI in light and dark mode, respectively. Format: `RRGGBB`, e.g. `28bb93`.
 - `icon` - a URL to an image file. E.g. `https://www.example.com/logo.png` (remember to URL-encode it!).
 - `fontFamily` - one of the fonts listed in the dashboard (see previous section). E.g. `Roboto`.
 - `darkMode` - when set to `true`, dark mode will be turned on by default when the app portal is opened.
@@ -241,7 +241,7 @@ The supported parameters are:
 So for example:
 
 ```
-http://app.svix.com/login?primaryColor=28bb93&darkMode=true&fontFamily=Roboto#key=eyJhcHBJZCI6ICJhcHBfMXRSdFlMN3pwWWR2NHFuWTRRZFI1azE4eXQ0IiwgInRva2VuIjogImFwcHNrX2UxOUN0Rm5hbTFoOU1Gamh5azRSMTUzNUNSd05VSWI0In0=
+http://app.svix.com/login?primaryColorLight=28bb93&primaryColorDark=22cc91&darkMode=true&fontFamily=Roboto#key=eyJhcHBJZCI6ICJhcHBfMXRSdFlMN3pwWWR2NHFuWTRRZFI1azE4eXQ0IiwgInRva2VuIjogImFwcHNrX2UxOUN0Rm5hbTFoOU1Gamh5azRSMTUzNUNSd05VSWI0In0=
 ```
 
 ## Implementing your own Consumer App Portal functionality

--- a/docs/app-portal.mdx
+++ b/docs/app-portal.mdx
@@ -241,7 +241,7 @@ The supported parameters are:
 So for example:
 
 ```
-http://app.svix.com/login?primaryColorLight=28bb93&primaryColorDark=22cc91&darkMode=true&fontFamily=Roboto#key=eyJhcHBJZCI6ICJhcHBfMXRSdFlMN3pwWWR2NHFuWTRRZFI1azE4eXQ0IiwgInRva2VuIjogImFwcHNrX2UxOUN0Rm5hbTFoOU1Gamh5azRSMTUzNUNSd05VSWI0In0=
+http://app.svix.com/login?primaryColorLight=22cc91&primaryColorDark=28bb93&darkMode=true&fontFamily=Roboto#key=eyJhcHBJZCI6ICJhcHBfMXRSdFlMN3pwWWR2NHFuWTRRZFI1azE4eXQ0IiwgInRva2VuIjogImFwcHNrX2UxOUN0Rm5hbTFoOU1Gamh5azRSMTUzNUNSd05VSWI0In0=
 ```
 
 ## Implementing your own Consumer App Portal functionality


### PR DESCRIPTION
We now have the `primaryColorLight` and `primaryColorDark` params. Use those instead of `primaryColor` in the docs. 

Technically, `primaryColor` is still supported (for backwards compatibility), but going forward, we should just use light and dark, therefore we can hide primaryColor from the docs.