### PR TITLE
Add Event Types Github Action to docs

### DIFF
--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -636,6 +636,19 @@ curl -X POST "https://api.svix.com/api/v1/event-type/import/openapi/" \
 </TabItem>
 </CodeTabs>
 
+#### Using the Github Action
+
+Svix also provides a [Github Action](https://github.com/svix/svix-event-type-import-action) to upload your OpenAPI spec and automatically create or update your event types as part of your CI/CD pipeline.
+
+```yaml
+- name: Upload Event Types to Svix
+  uses: svix/svix-event-type-import-action@v1.0.0
+  with:
+    openapi-file: 'path/to/your/openapi-spec.yml' # can be a .json too
+    svix-api-key: ${{ secrets.SVIX_API_KEY }}
+```
+
+
 ## Publishing your Event Catalog
 
 By default, your event types are only accessible to users from within an authenticated session on the Application Portal.

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "@types/react-router-dom": "^5.1.7",
     "typescript": "^4.2.2"
   },
+  "resolutions": {
+    "loader-utils@npm:^2.0.0": "2.0.4"
+  },
   "packageManager": "yarn@3.3.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9326,20 +9326,20 @@ fsevents@~2.3.2:
   linkType: hard
 
 "loader-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "loader-utils@npm:2.0.0"
+  version: 2.0.4
+  resolution: "loader-utils@npm:2.0.4"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^2.1.2
-  checksum: 6856423131b50b6f5f259da36f498cfd7fc3c3f8bb17777cf87fdd9159e797d4ba4288d9a96415fd8da62c2906960e88f74711dee72d03a9003bddcd0d364a51
+  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
   languageName: node
   linkType: hard
 
 "loader-utils@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "loader-utils@npm:3.2.0"
-  checksum: c7b9a8dc4b3bc19e9ef563c48e3a18ea9f8bb2da1ad38a12e4b88358cfba5f148a7baf12d78fe78ffcb718ce1e062ab31fcf5c148459f1247a672a4213471e80
+  version: 3.2.1
+  resolution: "loader-utils@npm:3.2.1"
+  checksum: 4e3ea054cdc8be1ab1f1238f49f42fdf0483039eff920fb1d442039f3f0ad4ebd11fb8e584ccdf2cb7e3c56b3d40c1832416e6408a55651b843da288960cc792
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<img width="935" alt="Screenshot 2023-11-17 at 12 01 33 PM" src="https://github.com/svix/svix-docs/assets/133019767/0cf6faf2-162d-4af5-9f18-f9285bca5e04">

Also added a resolution to fix the build in newer Node versions (similar to https://github.com/svix/www/pull/204)