### PR TITLE
Fix typos, detect them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typos:
+    name: Check for typos
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.18.0

--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -732,7 +732,7 @@ svixClient := svix.New("AUTH_TOKEN", nil)
 app, err := svixClient.EventType.Create(ctx, &svix.EventTypeIn{
     Name: "user.signup",
     Description: "A user has signed up",
-    FeatureFlag: svix.NullableStrig("beta-feature-a"),
+    FeatureFlag: svix.NullableString("beta-feature-a"),
 })}
 ```
 
@@ -837,7 +837,7 @@ curl -X POST "https://api.svix.com/api/v1/event-type/" \
 </TabItem>
 </CodeTabs>
 
-If a user tries to retrieve this newly created event type they will get a not-found error. To give them access you need to give them an access token that explicity allows them to see event types with the feature flag set during creation.
+If a user tries to retrieve this newly created event type they will get a not-found error. To give them access you need to give them an access token that explicitly allows them to see event types with the feature flag set during creation.
 
 <CodeTabs>
 <TabItem value="js">

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -350,7 +350,7 @@ Svix supports [idempotency](https://en.wikipedia.org/wiki/Idempotence) for safel
 
 For more information, please refer to the [idempotency section](./idempotency.mdx) of the docs.
 
-Note: while the `eventId` can potentially be used to enforce short-term uniqueness (similar to idempotency), it's recommended to use the idempotency mechanism when needed rather than using on the `eventId` checks.
+Note: while the `eventId` can potentially be used to enforce short-term uniqueness (similar to idempotency), it's recommended to use the idempotency mechanism when needed rather than relying on `eventId` checks.
 
 
 ## Add webhook endpoints

--- a/docs/receiving/using-app-portal/testing-events.mdx
+++ b/docs/receiving/using-app-portal/testing-events.mdx
@@ -2,7 +2,7 @@
 title: Testing Events
 ---
 
-The easiest way to be more confident in your endpoint configuation
+The easiest way to be more confident in your endpoint configuration
 is to start receiving events as quickly as possible.
 
 That's why we have a "Testing" tab for you to send example events

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -384,7 +384,7 @@ def webhook_handler(request):
     except WebhookVerificationError as e:
         return HttpResponse(status=400)
 
-    # Do someting with the message...
+    # Do something with the message...
 
     return HttpResponse(status=204)
 ```
@@ -409,7 +409,7 @@ def webhook_handler():
     except WebhookVerificationError as e:
         return ('', 400)
 
-    # Do someting with the message...
+    # Do something with the message...
 
     return ('', 204)
 ```
@@ -435,7 +435,7 @@ async def webhook_handler(request: Request, response: Response):
         response.status_code = status.HTTP_400_BAD_REQUEST
         return
 
-    # Do someting with the message...
+    # Do something with the message...
 ```
 
 ### Node.js (Next.js)


### PR DESCRIPTION
First grammatical error may need review to check if the fix preserves the intention of the sentence. According to `git blame`, @tasn wrote it.