### PR TITLE
Improvements to Rust client library usage docs

### DIFF
--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -41,7 +41,7 @@ go get github.com/svix/svix-webhooks/go
 <TabItem value="rust">
 
 ```toml
-svix = "0"
+svix = "1.20.0"
 ```
 
 </TabItem>

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -41,6 +41,7 @@ go get github.com/svix/svix-webhooks/go
 <TabItem value="rust">
 
 ```toml
+http = "1.0.0"
 svix = "1.20.0"
 ```
 
@@ -219,7 +220,7 @@ use svix::webhooks::Webhook;
 
 let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw".to_string();
 
-let mut headers = http::header::HeaderMap::new();
+let mut headers = http::HeaderMap::new();
 headers.insert("svix-id", "msg_p5jXN8AQM9LWM0D4loKWxJek");
 headers.insert("svix-timestamp", "1614265330");
 headers.insert(

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -254,7 +254,7 @@ String payload = "{\"test\": 2432232314}";
 Webhook webhook = new Webhook(secret);
 
 webhook.verify(payload, headers)
-// throws WebhookVerificationError exception on failure. 
+// throws WebhookVerificationError exception on failure.
 ```
 
 </TabItem>

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -40,7 +40,7 @@ go get github.com/svix/svix-webhooks/go
 <TabItem value="rust">
 
 ```toml
-svix = "0"
+svix = "1.20.0"
 ```
 
 </TabItem>


### PR DESCRIPTION
cc https://github.com/svix/svix-webhooks/issues/1245, I think the user who reported that issue might be on an outdated version of the client library because they copied the outdated dependency specification from our docs.