### PR TITLE
Document current 'Endpoint disabled' behavior

### DIFF
--- a/docs/retries.mdx
+++ b/docs/retries.mdx
@@ -35,7 +35,8 @@ After the conclusion of the above attempts the message will be marked as `Failed
 
 ## Disabling failing endpoints
 
-If all attempts to a specific endpoint fail for a period of 5 days, the endpoint will be disabled and a webhook (`EndpointDisabledEvent`) will be sent to your account (not to the failing endpoint).
+If all attempts to a specific endpoint fail for a period of 5 days, the endpoint will be disabled and an operational webhook (`EndpointDisabledEvent`) will be sent to your account.
+The clock only starts after multiple deliveries failed within a 24 hour span, with at least 12 hours difference between the first and the last failure.
 
 You can disable this behavior from the [Environment settings page](https://dashboard.svix.com/settings/organization/general-settings) on the dashboard.
 


### PR DESCRIPTION
We now mention the 12-24 hour window required for the second failure