### PR TITLE
Fix Rust verification example to borrow

### DIFF
--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -721,7 +721,7 @@ pub async fn webhook_in(headers: HeaderMap, body: Bytes) -> StatusCode {
         return StatusCode::INTERNAL_SERVER_ERROR;
     }
 
-    if let Err(_) = wh.verify(body, headers) {
+    if let Err(_) = wh.verify(&body, &headers) {
         return StatusCode::BAD_REQUEST;
     }
 


### PR DESCRIPTION
The rust verification example should borrow the body and the headermap instead.

https://docs.rs/svix/latest/svix/webhooks/struct.Webhook.html#method.verify