### PR TITLE
Fix Admonition titles

### DIFF
--- a/docs/event-types.mdx
+++ b/docs/event-types.mdx
@@ -14,7 +14,7 @@ Event types are just a string, for example: `user.signup`, `invoice.paid` and `w
 
 Webhook consumers can choose which events are sent to which endpoint. By default, all messages are sent to all endpoints. Though when adding or editing endpoints, users can choose to only subscribe to some of the event types for this particular endpoint.
 
-:::tip Bulk Create
+:::tip[Bulk Create]
 It's recommended to add the event types you are going to use ahead of time. You can do it by [importing them from an OpenAPI spec](#import-event-types-from-an-openapi-specification) or [bulk creating them from code](#bulk-creating-event-types-from-code).
 :::
 
@@ -32,7 +32,7 @@ Event types have a pattern defined a `^[a-zA-Z0-9\\-_.]+$`, meaning it can conta
 - 0 through 9
 - Special characters: `-`, `_`, `.`
 
-:::tip Style guide
+:::tip[Style guide]
 We recommend you use period-delimited event type names (e.g. `<group>.<event>`). If you do, the App Portal UI will logically group them for your users and make it easier for them to subscribe an endpoint to all events in a particular group of event types.
 :::
 
@@ -1077,7 +1077,7 @@ curl -X POST "https://api.svix.com/api/v1/event-type/user.signup/" \
 </TabItem>
 </CodeTabs>
 
-:::info Important
+:::info[Important]
 Keep in mind that endpoints with no event type filtering will receive all messages regardless of feature flags. Also, users with knowledge of a feature flag-gated event type can subscribe to that event type regardless of feature flags.
 Feature flags only impact event types' visibility in the catalog and the API, not their deliverability.
 :::

--- a/docs/integrations/advanced-zapier.mdx
+++ b/docs/integrations/advanced-zapier.mdx
@@ -9,7 +9,7 @@ The Svix auto-generated Zapier integration is a Node/JavaScript project meaning 
 
 This doc gives guidance on ways to enhance your Zapier webhook integration powered by Svix.
 
-:::info Prerequisites
+:::info[Prerequisites]
 Before reading this doc, we strongly recommend reading the [Build a Zapier Integration](./zapier) docs.
 This doc assumes you're familiar with the basics of Svix Integrations and have a functional API key-based Zapier webhook integration.
 :::

--- a/docs/integrations/zapier.mdx
+++ b/docs/integrations/zapier.mdx
@@ -28,7 +28,7 @@ Follow the [Your first event type schema](/tutorials/event-type-schema) tutorial
 
 ### Set up Zapier CLI
 
-:::info
+:::info[Information]
 Zapier integrations can be defined on the Zapier UI or via the Zapier CLI (as a Node/JavaScript package). This guide is based on the CLI which allows for more powerful customizations. We recommend reading through the [How to Use REST Hooks in Zapier CLI](https://platform.zapier.com/cli_tutorials/resthooks) tutorial provided by Zapier to get an understanding of the structure.
 :::
 

--- a/docs/integrations/zapier.mdx
+++ b/docs/integrations/zapier.mdx
@@ -28,7 +28,7 @@ Follow the [Your first event type schema](/tutorials/event-type-schema) tutorial
 
 ### Set up Zapier CLI
 
-:::info Information
+:::info
 Zapier integrations can be defined on the Zapier UI or via the Zapier CLI (as a Node/JavaScript package). This guide is based on the CLI which allows for more powerful customizations. We recommend reading through the [How to Use REST Hooks in Zapier CLI](https://platform.zapier.com/cli_tutorials/resthooks) tutorial provided by Zapier to get an understanding of the structure.
 :::
 
@@ -265,7 +265,7 @@ Zapier will prompt you to sign in to an account for the integration. When you cr
 
 ![zap-creation-step-2](../img/zap-creation-step-2.png)
 
-:::info User Authentication Experience
+:::info[User Authentication Experience]
 By default, the auto-generated Zapier integration uses token-based auth where your users input the application ID and an integration key. You can set up OAuth or Session-based authentication schemes to mask these Svix constructs by following the guide in the [Advanced Zapier Integrations](./advanced-zapier#alternative-authentication-schemes) doc.
 :::
 

--- a/docs/polling-endpoints.mdx
+++ b/docs/polling-endpoints.mdx
@@ -38,7 +38,6 @@ Then, using the iterator in the next call, they can iterate through the events a
 ```bash
 curl \
   "https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q?iterator=eyJv..." \
-  -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer sk_poll_*****.eu'
 ```

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -21,7 +21,7 @@ For more information, please refer to the [Overview section](overview.mdx).
 
 Get your authentication token (`AuthToken`) from the [Svix dashboard](https://dashboard.svix.com).
 
-:::info Automatic environment detection
+:::info[Automatic environment detection]
 The Svix libraries automatically infer the correct server URL from the authentication token when using the hosted Svix server. No action needed.
 
 If you are self-hosting the server, you will need to explicitly set the server URL yourself. Please refer to the [custom server URL](#custom-server-url) section below.

--- a/docs/receiving/source-ips.mdx
+++ b/docs/receiving/source-ips.mdx
@@ -40,6 +40,6 @@ This is the full list of IP addresses that webhooks may originate from grouped b
 </code>
 </pre>
 
-:::info Important
+:::info[Important]
 Static source IPs are not guaranteed for all pricing tiers, please refer to [the pricing page](https://www.svix.com/pricing/) for more information.
 :::

--- a/docs/receiving/using-app-portal/adding-endpoints.mdx
+++ b/docs/receiving/using-app-portal/adding-endpoints.mdx
@@ -9,7 +9,7 @@ listen to.
 
 ![add endpoint](/img/app-portal/add-endpoint.png)
 
-:::tip Svix Play
+:::tip[Svix Play]
 
 If you don't have a URL or your service isn't quite ready to start receiving events just yet,
 just press the **use Svix Play** button to have a unique URL generated for you.

--- a/docs/receiving/using-app-portal/polling-endpoints.mdx
+++ b/docs/receiving/using-app-portal/polling-endpoints.mdx
@@ -20,7 +20,6 @@ You can call this endpoint directly once you have an [API key](/receiving/using-
 ```bash
 curl \
   "https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q" \
-  -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer sk_poll_*****.eu'
 ```
@@ -40,7 +39,6 @@ Then, using the iterator in the next call, you can iterate through the events an
 ```bash
 curl \
   -X GET "https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q?iterator=eyJv..." \
-  -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer sk_poll_*****.eu'
 ```

--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -133,7 +133,7 @@ pacman -S curl
 
 Then verify webhooks using the code below. The payload is the raw (string) body of the request, and the headers are the headers passed in the request.
 
-:::caution Use the raw request body
+:::caution[Use the raw request body]
 
 You need to use the raw request body when verifying webhooks, as the cryptographic signature is sensitive to even the slightest changes.
 You should watch out for frameworks that parse the request as JSON and then stringify it because this too will break the signature verification.

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -6,7 +6,7 @@ Webhooks are a very powerful tool, and when used correctly are also very secure.
 
 For more information about the security measures taken by the Svix service, please refer to the [Svix security page](https://www.svix.com/security/).
 
-:::info Optional reading ahead
+:::info[Optional reading ahead]
 The section below is not required for the normal operation of the Svix service. It's only included here for educational purposes.
 :::
 

--- a/docs/tutorials/connectors.mdx
+++ b/docs/tutorials/connectors.mdx
@@ -2,7 +2,7 @@
 title: Configuring the Slack Connector
 ---
 
-:::info Prerequisites
+:::info[Prerequisites]
 This guide assumes your familiar with the basics of [event types](../event-types), the [App Portal](../app-portal) and [Connectors](../connectors).
 :::
 

--- a/docs/tutorials/event-type-schema.mdx
+++ b/docs/tutorials/event-type-schema.mdx
@@ -2,7 +2,7 @@
 title: Your first event type schema
 ---
 
-:::note Prerequisites
+:::note[Prerequisites]
 This guide assumes your familiar with the basics of [event types](../event-types) and the [App Portal](../app-portal).
 :::
 


### PR DESCRIPTION
Admonitions with titles were not showing properly since the syntax was wrong (I think it changed in the newer version of docusaurus?). I did a search and replace to fix all of them. 

**Before**
<img width="905" alt="Screenshot 2025-02-13 at 11 47 05 AM" src="https://github.com/user-attachments/assets/9513dfe5-86bd-482a-b102-d9be158b4b59" />

**After**
<img width="912" alt="Screenshot 2025-02-13 at 11 46 10 AM" src="https://github.com/user-attachments/assets/3c9b00d8-b55a-4362-849c-20ecf9e90869" />

