### PR TITLE
Update brew install to correct package

### DIFF
--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -109,7 +109,7 @@ dotnet add package Svix
 
 On macOS install via <a href="https://brew.sh/">Homebrew</a>:
 ```sh
-brew install svix/svix/svix
+brew install svix/svix/svix-cli
 ```
 
 On Windows install via <a href="https://scoop.sh/">Scoop</a>:

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -101,7 +101,7 @@ dotnet add package Svix
 On macOS install via <a href="https://brew.sh/">Homebrew</a>:
 
 ```sh
-brew install svix/svix/svix
+brew install svix/svix/svix-cli
 ```
 
 On Windows install via <a href="https://scoop.sh/">Scoop</a>:

--- a/docs/tutorials/cli.mdx
+++ b/docs/tutorials/cli.mdx
@@ -28,7 +28,7 @@ To install the Svix CLI with [Homebrew](https://brew.sh), run:
 
 
 ```sh
-brew install svix/svix/svix
+brew install svix/svix/svix-cli
 ```
 </TabItem>
 <TabItem value="scoop">


### PR DESCRIPTION
Our cli homebrew package was renamed `svix-cli` instead of `svix`