### PR TITLE
Fix typo in OpenTelemetry page title

### DIFF
--- a/docs/opentelemetry-streaming.mdx
+++ b/docs/opentelemetry-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemtry Streaming
+title: OpenTelemetry Streaming
 ---
 
 :::info[Important]


### PR DESCRIPTION
Subject says it all. Small typo in the page title: 

OpenTelemtry -> OpenTelemetry