### PR TITLE
Bridge: docs for the `svix-message-poller` receiver input

### DIFF
--- a/docs/advanced-endpoints/polling-endpoints.mdx
+++ b/docs/advanced-endpoints/polling-endpoints.mdx
@@ -52,4 +52,56 @@ curl \
 
 Messages will be returned in the order they were sent to Svix.
 
+### Polling with a Server-tracked Iterator
+
+By polling with a **Consumer ID**,  the server will track the client's progress as it iterates through the stream of
+messages.
+
+> Consumer IDs are arbitrary strings used by a client to self-identify.
+>
+> Note that Consumer IDs should be _unique per client_ and should not be shared. Put another way, Consumer IDs track
+> exclusive sequential access through the stream of messages.
+> Shared concurrent access through a given Consumer ID will result in errors as mutual clients drift in their positions
+> in the stream.
+
+Usage is the same, and still relies on sending the `iterator` parameter to move forward through the stream.
+Server tracking of the client's iterator is opt-in by adding a trailing `/consumer/CONSUMER_ID` to the Polling Endpoint
+URL.
+
+```bash
+curl \
+  "https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q/consumer/MY-CONSUMER-ID?iterator=eyJv..." \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer sk_poll_*****.eu'
+```
+
+The big difference is the server "remembers" the last `iterator` used to make a request for the given Consumer ID
+such that subsequent requests _without a `iterator`_ will resume using that last seen value.
+This is useful for situations where a process may be interrupted and lose its place while polling.
+
+In summation, when using Consumer IDs you need to provide an `iterator` in order to move forward, but you don't have to
+worry about losing progress or starting over if you lose an iterator for any reason.
+Poll the stream using the Consumer ID, omitting the `iterator` parameter, and you'll pick up where you left off.
+At that stage, use the provided `iterator` given in the response to start moving forward again.
+
+### Updating a Server-tracked Iterator with Seek
+
+The `iterator` persisted on the server side can be adjusted with the `seek` endpoint.
+
+```bash
+curl \
+  "https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q/consumer/MY-CONSUMER-ID/seek" \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk_poll_*****.eu' \
+  -d '{"after": "2025-01-17T00:00:00.0Z"}'
+```
+
+Note that after performing a `seek`, active clients sending a now-out-of-sequence `iterator` may see errors.
+In this situation, omitting the `iterator` parameter (as if making a new "initial" request) will allow such clients
+to pick up from the position tracked by the server. Subsequent requests should then use the iterator value returned
+in each response body.
+
+---
+
 Polling Endpoints can be used in parallel with regular Svix webhooks, and you don't need to make any changes to how you [create messages](/quickstart#send-a-message).

--- a/docs/receiving/verifying-payloads/receiving-with-bridge.mdx
+++ b/docs/receiving/verifying-payloads/receiving-with-bridge.mdx
@@ -8,6 +8,9 @@ import TabItem from '@theme/TabItem';
 
 [Svix Bridge] is useful in cases where you want to consume webhooks and write the payloads to a message queue.
 
+
+## Using the Built-in HTTP Server
+
 Since Bridge can act as an HTTP server, you can configure it as an Endpoint in Svix.
 Bridge can even verify webhooks when configured with an `endpoint_secret`.
 
@@ -44,6 +47,50 @@ in a new message published to the `acme` queue.
 This is to say, if you're running Bridge at `https://my-bridge.example.com`, the full URL you'd register as a Svix
 Endpoint would be `https://my-bridge.example.com/webhook/acme`.
 See [Adding Endpoints](../using-app-portal/adding-endpoints.mdx) for more on how to do this in the App Portal.
+
+
+## Using A Polling Endpoint
+
+Bridge can consume messages sent to [Ingest](/receiving/receiving-with-ingest) or any Svix Application with a
+[Polling Endpoint](/advanced-endpoints/polling-endpoints) configured as a destination.
+
+This is a great option if you don't want to run a public-internet-facing HTTP server to receive webhooks.
+Since Bridge initiates requests from within your environment, you don't need to open any ports in your firewall!
+
+```yaml
+receivers:
+  - name: "msg-poller-to-rabbitmq-example"
+    input:
+      type: "svix-message-poller"
+      # The consumer id should be unique per the app & sink.
+      # This is used to track Bridge's position in the stream so it can resume where it left off
+      # after restarting, etc.
+      consumer_id: "my-consumer"
+      # The app id, and sink id can be found in the URL for the corresponding Polling Endpoint.
+      # Eg:
+      # https://api.svix.com/api/v1/app/app_2mG6DgUaGlwCNdM5oRCUJec2kQC/poller/poll_59q
+      #                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        ^^^^^^^^
+      app_id: "app_XXXX"
+      sink_id: "poll_XXXX"
+      # The token can be seen in the UI for the corresponding Polling Endpoint.
+      token: "${POLLING_ENDPOINT_TOKEN}"
+
+    transformation: |
+      function handler(input) {
+        let event_type = input.eventType;
+        delete input.eventType;
+        // The `payload` field is what will be published to the queue.
+        return { payload: { event_type, ...input } };
+      }
+
+    output:
+      type: "rabbitmq"
+      uri: "${QUEUE_URI}"
+      exchange: ""
+      routing_key: "my_queue"
+```
+
+---
 
 Check out the the project on [GitHub][Svix Bridge] for more on how to get started with Bridge.
 


### PR DESCRIPTION
Also adds some details about the consumer API to the polling endpoints docs.