### PR TITLE
Fix Rust verification example

### DIFF
--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -716,10 +716,9 @@ use hyper::HeaderMap;
 pub const SECRET: &'static str = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
 
 pub async fn webhook_in(headers: HeaderMap, body: Bytes) -> StatusCode {
-    let wh = svix::webhooks::Webhook::new(SECRET);
-    if let Err(_) = wh {
+    let Ok(wh) = svix::webhooks::Webhook::new(SECRET) else {
         return StatusCode::INTERNAL_SERVER_ERROR;
-    }
+    };
 
     if let Err(_) = wh.verify(&body, &headers) {
         return StatusCode::BAD_REQUEST;


### PR DESCRIPTION
Fix the problem that `verify` call happens on the `Result<Webhook, WebhookError>` instead of `Webhook` type.

### Explanation

The method `new` returns `Result<Self, WebhookError>`, so the next call is failing due to the invalid type:

```rust
if let Err(_) = wh.verify(&body, &headers)
```

This makes sure that when we reach that line, the `wh` is known to be `Ok`.