### PR TITLE
Add app-portal-oss page

### DIFF
--- a/docs/app-portal/oss.mdx
+++ b/docs/app-portal/oss.mdx
@@ -2,7 +2,7 @@
 title: Consumer App Portal (OSS)
 ---
 
-The [Consumer Application Portal](../app-portal) is currently only included in the [hosted version of Svix](https://www.svix.com) and not in the open source version.
+The [Consumer Application Portal](/app-portal) is currently only included in the [hosted version of Svix](https://www.svix.com) and not in the open source version.
 This is probably going to change in the future, but for now you can just build your own.
 
 Fortunately, building your own is fairly simple using [`svix-react`] if you use React,


### PR DESCRIPTION
The page felt a bit too empty with just explanatory text plus the links mentioned in the issue. So instead of linking to the "Implementing your own Consumer App Portal functionality" section of the main app-portal page, I copy-pasted its example.

Closes https://github.com/svix/monorepo-private/issues/11098.