### PR TITLE
Remove extra php tab (we define php like any other tab)

### DIFF
--- a/docs/receiving/verifying-payloads/how.mdx
+++ b/docs/receiving/verifying-payloads/how.mdx
@@ -11,10 +11,7 @@ As shown in the [Why Verify section](./why.mdx), verifying operational webhooks 
 
 First install the libraries if you haven't already:
 
-<CodeTabs
-  additionalTabs={[
-    { label: 'PHP', value: 'php', },
-  ]}>
+<CodeTabs>
 <TabItem value="js">
 
 ```js
@@ -144,10 +141,7 @@ See examples below for how to get the raw request body with different frameworks
 
 The signature you should get from where you added the endpoint, e.g. the application portal.
 
-<CodeTabs
-  additionalTabs={[
-    { label: 'PHP', value: 'php', },
-  ]}>
+<CodeTabs>
 <TabItem value="js">
 
 ```js


### PR DESCRIPTION
fixes broken deployment of the docs site.