### PR TITLE
Fix sidebar margins and incorrect hover effect

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,7 +35,7 @@
 
 /* Better sidebar { */
 .menu a:not([href]).menu__link {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   margin-bottom: 0.5rem;
   color: black;
   font-size: 0.8rem;
@@ -44,8 +44,20 @@
   text-transform: uppercase;
 }
 
+.menu > .menu__list > .menu__list-item:first-child > .menu__list-item-collapsible > a:not([href]).menu__link {
+  margin-top: 0;
+}
+
+.menu__list-item-collapsible:has(> a:not([href]).menu__link):hover {
+  background: transparent;
+}
+
 html[data-theme="dark"] .menu a:not([href]).menu__link {
   color: grey;
+}
+
+html[data-theme="dark"] .menu__list-item-collapsible:has(> a:not([href]).menu__link):hover {
+  background: transparent;
 }
 
 /* } */

--- a/src/theme/ProductSwitcher/styles.module.css
+++ b/src/theme/ProductSwitcher/styles.module.css
@@ -9,9 +9,8 @@
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
-  width: 100%;
-  max-width: 280px;
-  margin: 1em auto;
+  width: calc(100% - 2em);
+  margin: 1em;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
The section titles had a hover effect, but they are not clickable. And the top padding was inconsistent. 

Also fixes the product switcher alignment in mobile screens

This has a bunch of CSS hacky-looking shit, I know, but it's just the way it works with docusaurus :(

**Before**
<img width="353" height="398" alt="Screenshot 2026-04-02 at 12 09 59 PM" src="https://github.com/user-attachments/assets/5f517d69-2d75-44be-adfd-ba9fda1cfcd2" />

**After**
<img width="330" height="355" alt="Screenshot 2026-04-02 at 12 10 10 PM" src="https://github.com/user-attachments/assets/3b9b4c86-3104-475b-bc51-2d5f5dd1b58c" />
