### PR TITLE
Render markdown on pages ending with '.md'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,7 @@ Session.vim
 public/_pagefind
 static/_pagefind
 
+# Generated markdown
+public/generated
+
 .cursor

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,6 +28,14 @@ const nextConfig: NextConfig = {
       { source: '/rate-limit', destination: '/throttling', permanent: true },
     ]
   },
+  rewrites: async () => {
+    return [
+      {
+        source: '/:path(.+)\\.md',
+        destination: '/generated/md/:path.md',
+      }
+    ]
+  },
   devIndicators: false,
   ...(process.env.CI && ciExportConfig),
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@fortawesome/react-fontawesome": "^3.3.1",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
-        "@truto/turndown-plugin-gfm": "^1.0.2",
         "accepts": "^1.3.8",
         "clsx": "^2.1.1",
         "next": "^16.2.3",
@@ -19,14 +18,12 @@
         "nextra-theme-docs": "^4.6.1",
         "posthog-js": "^1.369.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4",
-        "turndown": "^7.2.4"
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.10",
         "@types/node": "25.3.0",
         "@types/react": "19.2.14",
-        "@types/turndown": "^5.0.6",
         "pagefind": "^1.4.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^4.1.10"
@@ -851,12 +848,6 @@
       "dependencies": {
         "langium": "^4.0.0"
       }
-    },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/@napi-rs/simple-git": {
       "version": "0.1.22",
@@ -1810,22 +1801,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@shikijs/core": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
@@ -2242,21 +2217,6 @@
         "unist-util-visit": "^5.0.0"
       }
     },
-    "node_modules/@truto/turndown-plugin-gfm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@truto/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-EayTVTfRg4cTIPTIwC7bwY4jvCy4lz2V4NBDf1OHPr0fH044K5xs1LRy5tcjspOrL1do7FerVw2iqBglO2gxlg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.45.1"
-      },
-      "peerDependencies": {
-        "turndown": "^7.0.0"
-      }
-    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -2617,13 +2577,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/turndown": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
-      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -8588,19 +8541,6 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
-    },
-    "node_modules/turndown": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
-      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
     },
     "node_modules/twoslash": {
       "version": "0.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,22 @@
         "@fortawesome/react-fontawesome": "^3.3.1",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
+        "@truto/turndown-plugin-gfm": "^1.0.2",
+        "accepts": "^1.3.8",
         "clsx": "^2.1.1",
         "next": "^16.2.3",
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",
         "posthog-js": "^1.369.0",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "turndown": "^7.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.10",
         "@types/node": "25.3.0",
         "@types/react": "19.2.14",
+        "@types/turndown": "^5.0.6",
         "pagefind": "^1.4.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^4.1.10"
@@ -847,6 +851,12 @@
       "dependencies": {
         "langium": "^4.0.0"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@napi-rs/simple-git": {
       "version": "0.1.22",
@@ -1800,6 +1810,22 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
+      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@shikijs/core": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
@@ -2216,6 +2242,21 @@
         "unist-util-visit": "^5.0.0"
       }
     },
+    "node_modules/@truto/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@truto/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-EayTVTfRg4cTIPTIwC7bwY4jvCy4lz2V4NBDf1OHPr0fH044K5xs1LRy5tcjspOrL1do7FerVw2iqBglO2gxlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.45.1"
+      },
+      "peerDependencies": {
+        "turndown": "^7.0.0"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -2577,6 +2618,13 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2619,6 +2667,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/acorn": {
@@ -6906,6 +6967,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7005,6 +7087,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next": {
@@ -8497,6 +8588,19 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
     },
     "node_modules/twoslash": {
       "version": "0.3.8",

--- a/package.json
+++ b/package.json
@@ -12,18 +12,22 @@
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
+    "@truto/turndown-plugin-gfm": "^1.0.2",
+    "accepts": "^1.3.8",
     "clsx": "^2.1.1",
     "next": "^16.2.3",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "posthog-js": "^1.369.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",
     "@types/node": "25.3.0",
     "@types/react": "19.2.14",
+    "@types/turndown": "^5.0.6",
     "pagefind": "^1.4.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "next start",
     "pagefind-ci": "pagefind --site out --output-path out/_pagefind",
     "pagefind-vercel": "pagefind --site .next/server/app --output-path public/_pagefind",
-    "generate-md-vercel": "node scripts/generate-md.mjs .next/server/app public/generated/md"
+    "generate-md-vercel": "node scripts/generate-md.mjs content public/generated/md"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
@@ -13,7 +13,6 @@
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
-    "@truto/turndown-plugin-gfm": "^1.0.2",
     "accepts": "^1.3.8",
     "clsx": "^2.1.1",
     "next": "^16.2.3",
@@ -21,14 +20,12 @@
     "nextra-theme-docs": "^4.6.1",
     "posthog-js": "^1.369.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "turndown": "^7.2.4"
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",
     "@types/node": "25.3.0",
     "@types/react": "19.2.14",
-    "@types/turndown": "^5.0.6",
     "pagefind": "^1.4.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "scripts": {
     "dev": "next dev",
-    "build": "next build && npm run pagefind-vercel",
+    "build": "next build && npm run pagefind-vercel && npm run generate-md-vercel",
     "start": "next start",
     "pagefind-ci": "pagefind --site out --output-path out/_pagefind",
-    "pagefind-vercel": "pagefind --site .next/server/app --output-path public/_pagefind"
+    "pagefind-vercel": "pagefind --site .next/server/app --output-path public/_pagefind",
+    "generate-md-vercel": "node scripts/generate-md.mjs .next/server/app public/generated/md"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,6 +2,8 @@
 
 > The enterprise-ready webhook infrastructure. Svix is secure, reliable, and built for scale. The documentation for Svix
 
+A markdown version of any page is available by appending `.md` to the end of its path (e.g., `https://docs.svix.com/quickstart.md`).
+
 ## Docs
 
 - [Introduction](https://docs.svix.com/): Svix makes sending webhooks easy and reliable by offering webhook sending as a service. With Svix you can start sending webhooks in minutes, while ensuring robust deliverability, and a great developer experience for your users.

--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -1,0 +1,82 @@
+import { readFile, writeFile, mkdir, readdir, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import TurndownService from "turndown";
+import TurndownGFMPlugin from "@truto/turndown-plugin-gfm";
+
+const SKIP_FILES = new Set([
+  "404.html",
+  "500.html",
+  "_not-found.html",
+  "_error.html",
+]);
+
+async function* walkHtml(root) {
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (entry.name.startsWith("_") && entry.isDirectory()) continue;
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkHtml(full);
+    } else if (entry.isFile() && entry.name.endsWith(".html") && !SKIP_FILES.has(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+function extractMain(html) {
+  const bodyMatch = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  return bodyMatch ? bodyMatch[1] : html;
+}
+
+function buildTurndown() {
+  const td = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+    bulletListMarker: "-",
+  });
+  td.use(TurndownGFMPlugin);
+  td.remove(["script", "style", "noscript", "iframe"]);
+  td.addRule("strip-svg", {
+    filter: ["svg"],
+    replacement: (content) => content || "",
+  });
+  return td;
+}
+
+async function main() {
+  const [inputDir, outputDir] = process.argv.slice(2);
+  if (!inputDir || !outputDir) {
+    console.error("Usage: generate-md.mjs <input-dir> <output-dir>");
+    process.exit(1);
+  }
+
+  if (!existsSync(inputDir)) {
+    console.error(`Input directory does not exist: ${inputDir}`);
+    process.exit(1);
+  }
+
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const turndown = buildTurndown();
+  let count = 0;
+
+  for await (const file of walkHtml(inputDir)) {
+    const rel = relative(inputDir, file);
+    const html = await readFile(file, "utf8");
+    const md = turndown.turndown(extractMain(html)).trim() + "\n";
+
+    const outRel = rel.replace(/\.html$/, ".md");
+    const outPath = join(outputDir, outRel);
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, md, "utf8");
+    count++;
+  }
+
+  console.log(`Generated ${count} markdown files in ${outputDir}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/generate-md.mjs
+++ b/scripts/generate-md.mjs
@@ -1,52 +1,23 @@
 import { readFile, writeFile, mkdir, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, dirname, relative } from "node:path";
-import TurndownService from "turndown";
-import TurndownGFMPlugin from "@truto/turndown-plugin-gfm";
+import { join, dirname, relative, basename } from "node:path";
 
-const SKIP_FILES = new Set([
-  "404.html",
-  "500.html",
-  "_not-found.html",
-  "_error.html",
-]);
-
-async function* walkHtml(root) {
+async function* walkMdx(root) {
   for (const entry of await readdir(root, { withFileTypes: true })) {
-    if (entry.name.startsWith("_") && entry.isDirectory()) continue;
+    if (entry.name.startsWith("_")) continue;
     const full = join(root, entry.name);
     if (entry.isDirectory()) {
-      yield* walkHtml(full);
-    } else if (entry.isFile() && entry.name.endsWith(".html") && !SKIP_FILES.has(entry.name)) {
+      yield* walkMdx(full);
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
       yield full;
     }
   }
 }
 
-function extractMain(html) {
-  const bodyMatch = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
-  return bodyMatch ? bodyMatch[1] : html;
-}
-
-function buildTurndown() {
-  const td = new TurndownService({
-    headingStyle: "atx",
-    codeBlockStyle: "fenced",
-    bulletListMarker: "-",
-  });
-  td.use(TurndownGFMPlugin);
-  td.remove(["script", "style", "noscript", "iframe"]);
-  td.addRule("strip-svg", {
-    filter: ["svg"],
-    replacement: (content) => content || "",
-  });
-  return td;
-}
-
 async function main() {
   const [inputDir, outputDir] = process.argv.slice(2);
   if (!inputDir || !outputDir) {
-    console.error("Usage: generate-md.mjs <input-dir> <output-dir>");
+    console.error("Usage: generate-md.mjs <content-dir> <output-dir>");
     process.exit(1);
   }
 
@@ -58,18 +29,18 @@ async function main() {
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
-  const turndown = buildTurndown();
   let count = 0;
 
-  for await (const file of walkHtml(inputDir)) {
+  for await (const file of walkMdx(inputDir)) {
     const rel = relative(inputDir, file);
-    const html = await readFile(file, "utf8");
-    const md = turndown.turndown(extractMain(html)).trim() + "\n";
+    const content = await readFile(file, "utf8");
 
-    const outRel = rel.replace(/\.html$/, ".md");
+    const outRel = basename(rel) === "index.mdx"
+      ? dirname(rel) + ".md"
+      : rel.replace(/\.mdx$/, ".md");
     const outPath = join(outputDir, outRel);
     await mkdir(dirname(outPath), { recursive: true });
-    await writeFile(outPath, md, "utf8");
+    await writeFile(outPath, content, "utf8");
     count++;
   }
 


### PR DESCRIPTION
Basically what we did in https://github.com/svix/www/pull/414.
We cannot do https://github.com/svix/www/pull/416 because docs are statically generated, so we don't have access to a 'runtime' to read the headers. We can probably set this up via Vercel UI.. I need to check