### PR TITLE
Promote 'receiving-webhooks' skills

### DIFF
--- a/content/receiving/verifying-payloads/how-manual.mdx
+++ b/content/receiving/verifying-payloads/how-manual.mdx
@@ -7,6 +7,8 @@ title: Verifying Webhooks Manually
 
 The recommended way to verify webhooks is using our official libraries as outlined in the [How to Verify](./how.mdx) section.
 
+<ReceivingSkillCopy />
+
 </Callout>
 However, here are instructions for verifying manually for those who need it.
 

--- a/content/receiving/verifying-payloads/how.mdx
+++ b/content/receiving/verifying-payloads/how.mdx
@@ -128,7 +128,7 @@ pacman -S curl
 
 Then verify webhooks using the code below. The payload is the raw (string) body of the request, and the headers are the headers passed in the request.
 
-<Callout type="error">
+<Callout type="important">
 
 **Use the raw request body**
 

--- a/content/receiving/verifying-payloads/how.mdx
+++ b/content/receiving/verifying-payloads/how.mdx
@@ -5,6 +5,8 @@ title: How to Verify Webhooks with the Svix Libraries
 
 As shown in the [Why Verify section](./why.mdx), verifying operational webhooks is very important. This section describes how to do it.
 
+<ReceivingSkillCallout />
+
 ## Verifying using our official libraries
 
 First install the libraries if you haven't already:

--- a/content/receiving/verifying-payloads/why.mdx
+++ b/content/receiving/verifying-payloads/why.mdx
@@ -5,6 +5,8 @@ title: Why Verify Webhooks
 
 Because of the way webhooks work, attackers can impersonate services by simply sending a fake webhook to an endpoint. Think about it: it's just an HTTP POST from an unknown source. This is a potential security hole for many applications, or at the very least, a source of problems.
 
+<ReceivingSkillCallout />
+
 In order to prevent it, Svix signs every webhook and its metadata with a unique key for each endpoint. This signature can then be used to verify the webhook indeed comes from Svix, and only process it if it is.
 
 Another potential security hole is what's called replay attacks. A [replay attack](https://en.wikipedia.org/wiki/Replay_attack) is when an attacker intercepts a valid payload (including the signature), and re-transmits it to your endpoint. This payload will pass signature validation, and will therefore be acted upon.

--- a/content/receiving/webhooks-autoconfig.mdx
+++ b/content/receiving/webhooks-autoconfig.mdx
@@ -194,7 +194,7 @@ webhook.verify(payload, headers);
 
 `payload` and `headers` depend on the framework (see [Verifying Webhooks](/receiving/verifying-payloads/how)).
 
-<Callout type="info">
+<Callout type="important">
 
 **Use the raw request body when verifying webhooks**
 

--- a/content/receiving/webhooks-autoconfig.mdx
+++ b/content/receiving/webhooks-autoconfig.mdx
@@ -6,6 +6,8 @@ title: Receiving with Webhooks AutoConfig
 
 Webhooks AutoConfig is an easier way to configure and consume webhooks.
 
+<ReceivingSkillCallout />
+
 With AutoConfig, you can set your webhook endpoint URL, event types, and other configuration in code
 and AutoConfig will automatically ensure the settings are up to date. Configuration automatically changes when your
 code changes without needing to go to the UI and reconfigure the endpoint.

--- a/mdx-components.jsx
+++ b/mdx-components.jsx
@@ -3,7 +3,7 @@ import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs'
 import { CodeTabs } from './src/components/CodeTabs'
 import { CLITabs } from './src/components/CLITabs'
 import { SlackJoinLink } from './src/components/SlackJoinLink'
-import { AgentSkillsCallout } from './src/components/AgentSkillsCallout'
+import { AgentSkillsCallout, ReceivingSkillCallout, ReceivingSkillCopy } from './src/components/AgentSkillsCallout'
 import ConnectorLogo from './src/components/ConnectorLogo'
 import clsx from 'clsx'
 import Image from 'next/image'
@@ -33,5 +33,7 @@ export function useMDXComponents(components) {
     ConnectorLogo,
     SlackJoinLink,
     AgentSkillsCallout,
+    ReceivingSkillCallout,
+    ReceivingSkillCopy
   }
 }

--- a/src/components/AgentSkillsCallout.tsx
+++ b/src/components/AgentSkillsCallout.tsx
@@ -8,3 +8,21 @@ export function AgentSkillsCallout() {
     </Callout>
   )
 }
+
+export function ReceivingSkillCopy() {
+  return (
+    <>
+      <strong>Building with an AI coding agent?</strong>{' '}
+      The <a className="underline" href="https://github.com/svix/svix-agent-skills/tree/main/skills/receiving-webhooks"><code>receiving-webhooks</code></a> skill teaches Claude, Cursor, and other agents to verify webhooks the right way.<br />
+      Install with <code>npx skills add svix/svix-agent-skills --skill receiving-webhooks</code>.
+    </>
+  )
+}
+
+export function ReceivingSkillCallout() {
+  return (
+    <Callout type="info">
+      <ReceivingSkillCopy />
+    </Callout>
+  )
+}


### PR DESCRIPTION
This PR creates a new component named 'ReceivingSkillCallout' which promotes our new agent skill and adds it to the following pages
- https://docs.svix.com/receiving/verifying-payloads/why
- https://docs.svix.com/receiving/verifying-payloads/how
- https://docs.svix.com/receiving/verifying-payloads/how-manual
- https://docs.svix.com/receiving/webhooks-autoconfig