### PR TITLE
Fix autoconfig code examples

### DIFF
--- a/content/receiving/webhooks-autoconfig.mdx
+++ b/content/receiving/webhooks-autoconfig.mdx
@@ -44,9 +44,8 @@ Call `subscribe()` to complete the configuration.
 ```js
 import { AutoConfig } from "svix";
 
-const webhook = new AutoConfig({
-  token: AUTO_CONFIG_TOKEN,
-  eventTypes: ["invoice.paid", "user.created"],
+const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+  filterTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -56,14 +55,15 @@ await webhook.subscribe();
 
 <TabItem value="Python">
 ```python
-import os
-
-from svix.auto_configuration import AutoConfig
+from svix import AutoConfig
+from svix.models import EndpointIn
 
 webhook = AutoConfig(
-    token=AUTO_CONFIG_TOKEN,
-    event_types=["invoice.paid", "user.created"],
-    url="https://api.us.example.com/webhooks/acme",
+    AUTO_CONFIG_TOKEN,
+    EndpointIn(
+        url="https://api.us.example.com/webhooks/acme",
+        filter_types=["invoice.paid", "user.created"],
+    ),
 )
 
 webhook.subscribe()
@@ -72,11 +72,17 @@ webhook.subscribe()
 
 <TabItem value="Rust">
 ```rust
-let webhook = svix::AutoConfig::new(svix::AutoConfigOptions {
-    token: AUTO_CONFIG_TOKEN,
-    event_types: vec!["invoice.paid".to_string(), "user.created".to_string()],
-    url: "https://api.us.example.com/webhooks/acme".to_string(),
-});
+let webhook = svix::AutoConfig::new(
+    AUTO_CONFIG_TOKEN.to_string(),
+    svix::EndpointIn {
+        url: "https://api.us.example.com/webhooks/acme".to_string(),
+        filter_types: Some(vec![
+            "invoice.paid".to_string(),
+            "user.created".to_string(),
+        ]),
+        ..Default::default()
+    },
+)?;
 
 webhook.subscribe().await?;
 ```
@@ -85,13 +91,14 @@ webhook.subscribe().await?;
 <TabItem value="Go">
 ```go
 import (
+	"context"
 	svix "github.com/svix/svix-webhooks/go"
+	"github.com/svix/svix-webhooks/go/models"
 )
 
-webhook, err := svix.NewAutoConfig(svix.AutoConfigOptions{
-    Token:      AUTO_CONFIG_TOKEN,
-    EventTypes: []string{"invoice.paid", "user.created"},
-    URL:        "https://api.us.example.com/webhooks/acme",
+webhook, err := svix.NewAutoConfig(AUTO_CONFIG_TOKEN, models.EndpointIn{
+	Url:         "https://api.us.example.com/webhooks/acme",
+	FilterTypes: []string{"invoice.paid", "user.created"},
 })
 if err != nil {
     panic(err)
@@ -106,12 +113,14 @@ if err := webhook.Subscribe(ctx); err != nil {
 <TabItem value="Java">
 ```java
 import com.svix.AutoConfig;
-import java.util.List;
+import com.svix.models.EndpointIn;
+import java.util.Set;
 
 AutoConfig webhook = new AutoConfig(
         AUTO_CONFIG_TOKEN,
-        List.of("invoice.paid", "user.created"),
-        "https://api.us.example.com/webhooks/acme");
+        new EndpointIn()
+                .url("https://api.us.example.com/webhooks/acme")
+                .filterTypes(Set.of("invoice.paid", "user.created")));
 
 webhook.subscribe();
 ```
@@ -120,11 +129,14 @@ webhook.subscribe();
 <TabItem value="Kotlin">
 ```kotlin
 import com.svix.kotlin.AutoConfig
+import com.svix.kotlin.models.EndpointIn
 
 val webhook = AutoConfig(
-    token = AUTO_CONFIG_TOKEN,
-    eventTypes = listOf("invoice.paid", "user.created"),
-    url = "https://api.us.example.com/webhooks/acme",
+    AUTO_CONFIG_TOKEN,
+    EndpointIn(
+        url = "https://api.us.example.com/webhooks/acme",
+        filterTypes = setOf("invoice.paid", "user.created"),
+    ),
 )
 
 webhook.subscribe()
@@ -135,11 +147,12 @@ webhook.subscribe()
 ```ruby
 require "svix"
 
-webhook = Svix::AutoConfig.new(
-  token: AUTO_CONFIG_TOKEN,
-  event_types: ["invoice.paid", "user.created"],
-  url: "https://api.us.example.com/webhooks/acme",
+endpoint = Svix::EndpointIn.new(
+  "url" => "https://api.us.example.com/webhooks/acme",
+  "filterTypes" => ["invoice.paid", "user.created"],
 )
+
+webhook = Svix::AutoConfig.new(AUTO_CONFIG_TOKEN, endpoint)
 
 webhook.subscribe
 ```
@@ -149,11 +162,15 @@ webhook.subscribe
 ```csharp
 using System;
 using Svix;
+using Svix.Models;
 
 var webhook = new AutoConfig(
     AUTO_CONFIG_TOKEN,
-    new[] { "invoice.paid", "user.created" },
-    "https://api.us.example.com/webhooks/acme");
+    new EndpointIn
+    {
+        Url = "https://api.us.example.com/webhooks/acme",
+        FilterTypes = new[] { "invoice.paid", "user.created" },
+    });
 
 await webhook.SubscribeAsync();
 ```
@@ -161,11 +178,14 @@ await webhook.SubscribeAsync();
 
 <TabItem value="PHP">
 ```php
-$webhook = new \Svix\AutoConfig([
-    'token' => AUTO_CONFIG_TOKEN,
-    'eventTypes' => ['invoice.paid', 'user.created'],
-    'url' => 'https://api.us.example.com/webhooks/acme',
-]);
+use Svix\AutoConfig;
+use Svix\Models\EndpointIn;
+
+$webhook = new AutoConfig(
+    AUTO_CONFIG_TOKEN,
+    EndpointIn::create('https://api.us.example.com/webhooks/acme')
+        ->withFilterTypes(['invoice.paid', 'user.created']),
+);
 
 $webhook->subscribe();
 ```
@@ -186,9 +206,11 @@ When using Webhooks AutoConfig, payload verification is supported out of the box
 To verify the payload, call verify() on the same AutoConfig instance you used to subscribe. The AutoConfig token contains the secret key to verify the payload.
 
 ```typescript
-const webhook = new Svix.AutoConfig({
-  token: process.env.AUTO_CONFIG_TOKEN,
-  ...
+import { AutoConfig } from "svix";
+
+const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+  filterTypes: ["invoice.paid", "user.created"],
+  url: "https://api.us.example.com/webhooks/acme",
 });
 
 webhook.verify(payload, headers);
@@ -218,13 +240,12 @@ For example, in Express.js, you can call `subscribe()` in an Express.js server:
 
 ```js
 import express from "express";
-import { Svix } from "svix";
+import { AutoConfig } from "svix";
 
 const app = express();
 
-const webhook = new Svix.AutoConfig({
-  token: AUTO_CONFIG_TOKEN,
-  eventTypes: ["invoice.paid", "user.created"],
+const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+  filterTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -241,11 +262,10 @@ When using a serverless framework, there are lifecycle hooks where you can call 
 For example, in Next.js, you can use [instrumentation](https://nextjs.org/docs/app/guides/instrumentation) to subscribe when a new Next.js server instance is initiated.
 
 ```typescript
-import { Svix } from "svix";
+import { AutoConfig } from "svix";
 
-const webhook = new Svix.AutoConfig({
-  token: AUTO_CONFIG_TOKEN,
-  eventTypes: ["invoice.paid", "user.created"],
+const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+  filterTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -272,11 +292,10 @@ jobs:
       - run: npm ci
       - run: |
           node --input-type=module <<'EOF'
-          import { Svix } from "svix";
+          import { AutoConfig } from "svix";
 
-          const webhook = new Svix.AutoConfig({
-            token: AUTO_CONFIG_TOKEN,
-            eventTypes: ["invoice.paid", "user.created"],
+          const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+            filterTypes: ["invoice.paid", "user.created"],
             url: "https://api.us.example.com/webhooks/acme",
           });
 

--- a/content/webhooks-autoconfig.mdx
+++ b/content/webhooks-autoconfig.mdx
@@ -21,9 +21,8 @@ Here's an example of how this looks like in code:
 ```js
 import { AutoConfig } from "svix";
 
-const webhook = new AutoConfig({
-  token: AUTO_CONFIG_TOKEN,
-  eventTypes: ["invoice.paid", "user.created"],
+const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
+  filterTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 


### PR DESCRIPTION
I just realized I had all the code examples wrong, because I was using an old version of the API instead of what actually got shipped, and accidentally carried over the difference to the code examples. The token is a positional argument and the type of the second argument is `EndpointIn`

Also, `filterTypes` is correct instead of `eventTypes`, since that comes from the name we use in https://api.svix.com/docs#tag/Endpoint/operation/v1.endpoint.create.body.filterTypes

I doubled-checked the examples more carefully now, sorry :/ 