### PR TITLE
ci: Group dependabot GHA updates into one PR per week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     open-pull-requests-limit: 2
     cooldown:
       default-days: 3
+    groups:
+      workflows:
+        applies-to: version-updates
+        patterns:
+          - '*'
     schedule:
       interval: "weekly"
       day: "wednesday"


### PR DESCRIPTION
Right now, we get separate PRs per GitHub action that needs updates. For example: #293 and #294. They even conflicted with each other, making it more annoying to merge. With this, that won't happen again.