### PR TITLE
Document email notifications app_id query parameter

### DIFF
--- a/content/email-notifications.mdx
+++ b/content/email-notifications.mdx
@@ -403,7 +403,7 @@ curl -X PATCH "https://api.us.svix.com/api/v1/app/example-customer-123/" \
 
 ### Redirecting to your webhooks management page
 
-When the webhooks management page URL is included in emails, Svix adds `svix_app_id` as aquery parameter, with the application ID or UID as the value.
+When the webhooks management page URL is included in emails, Svix adds `svix_app_id` as a query parameter, with the application ID as the value (or the UID if the application has one).
 
 This can be used to redirect the user to the right page in your application, in cases where the URL varies per customer.
 

--- a/content/email-notifications.mdx
+++ b/content/email-notifications.mdx
@@ -401,6 +401,14 @@ curl -X PATCH "https://api.us.svix.com/api/v1/app/example-customer-123/" \
 </TabItem>
 </CodeTabs>
 
+### Redirecting to your webhooks management page
+
+When the webhooks management page URL is included in emails, Svix adds `svix_app_id` as aquery parameter, with the application ID or UID as the value.
+
+This can be used to redirect the user to the right page in your application, in cases where the URL varies per customer.
+
+For example, if the webhooks management page URL in your site is `app.example.com/webhooks/customer-123`, set the webhooks management URL to `app.example.com/webhooks`. Then, in your application, add a redirect from `/webhooks/?svix_app_id={APP_UID}` to `/webhooks/{APP_UID}`.
+
 ### An example email notification
 
 ![Email notification example](/img/email-notification-example.png)


### PR DESCRIPTION
This feature has been live (and used by a customer) for a while, but we never documented it (see https://github.com/svix/svix-webhooks-private/pull/4857)

No reason not to do it. A customer recently asked about this.