### PR TITLE
Use youtube-nocookie for video embed

### DIFF
--- a/content/opentelemetry-streaming.mdx
+++ b/content/opentelemetry-streaming.mdx
@@ -101,7 +101,7 @@ This video shows how you can quickly integrate Svix OpenTelemetry exports with G
   <iframe
     width="100%"
     height="100%"
-    src="https://www.youtube.com/embed/hzZBloVfjEU"
+    src="https://www.youtube-nocookie.com/embed/hzZBloVfjEU"
     allowFullScreen
   />
 </div>


### PR DESCRIPTION
youtube-nocookie is an official thing by youtube (https://support.google.com/youtube/answer/171780?hl=en#zippy=%2Cturn-on-privacy-enhanced-mode) that allows embedding videos with less (or no) tracking cookies. Using the regular youtube embed was flagged as non-compliant with cookie consent rules.

This is also recommended by cookiehub

The alternative is to keep youtube.com and not load this iframe if the user doesn't allow tracking cookies, but that would be much worse. I don't think we care about analytics in this youtube video anyway. 