### PR TITLE
Update opentelemetry docs

### DIFF
--- a/content/_common/otel-provider-notes.mdx
+++ b/content/_common/otel-provider-notes.mdx
@@ -1,0 +1,18 @@
+## Notes on Integrating with Specific Observability Platforms
+
+Most major APM/Observability platforms support OpenTelemetry ingestion with minimal configuration. Depending on the specific tool, you use, you may need to add specific headers in order for ingestion to work correctly.
+
+### Coralogix
+Coralogix OpenTelemetry integration generally works by adding the following custom headers to your OpenTelemetry configuration:
+* `CX-Application-Name` (Should be set to the environment name that produces the data)
+* `CX-Subsystem-Name` (Should be set to the name of the service that produces the data)
+
+See [Coralogix OpenTelemetry documentation](https://coralogix.com/docs/opentelemetry/getting-started/) for further details.
+
+### New Relic
+New Relic also offers support for consuming OpenTelemetry Data, but you will need to add the following custom header to your configuration:
+* `api-key` (Must be set to your license key)
+
+See [New Relic OpenTelemetry documentation](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/) for further details.
+
+For additional instructions on how to integrate your specific observability platform with OpenTelemetry, please refer to your specific provider's documentation or [contact Svix support](https://www.svix.com/contact/).

--- a/content/advanced-endpoints/otel-tracing.mdx
+++ b/content/advanced-endpoints/otel-tracing.mdx
@@ -1,6 +1,8 @@
 ---
 title: OpenTelemetry Tracing
 ---
+import OpenTelemetryProviderNotes from '../_common/otel-provider-notes.mdx'
+
 # OpenTelemetry Tracing
 
 Svix can deliver webhooks directly to an OpenTelemetry tracing collector as spans, without your customers having to set up any listener endpoint or write any glue code.
@@ -158,7 +160,7 @@ function handler(input) {
 
             // We use the eventType as the name of the span,
             // as it makes it easier to identify which events map to
-            // which spans in Grafana
+            // which spans in your OpenTelemetry platform.
             name: event.eventType,
 
             // We use the msgId as the traceIdKey, to ensure that all spans for the same
@@ -193,6 +195,10 @@ function handler(input) {
 }
 ```
 
-When the endpoint receives these webhooks, they'll be dispatched to Grafana. Here, we can see `msg_1234` as its own isolated trace, with the `message.attempt` and `http.attempt` spans correctly grouped together, with the expected attributes.
+When the endpoint receives these webhooks, they'll be dispatched to your observability platform.
+
+In this Grafana view, we can see `msg_1234` as its own isolated trace, with the `message.attempt` and `http.attempt` spans correctly grouped together, with the expected attributes.
 
 ![grafana-example](/img/stream/grafana-dashboard.png)
+
+<OpenTelemetryProviderNotes />

--- a/content/opentelemetry-streaming.mdx
+++ b/content/opentelemetry-streaming.mdx
@@ -1,6 +1,8 @@
 ---
 title: OpenTelemetry Streaming
 ---
+import OpenTelemetryProviderNotes from './_common/otel-provider-notes.mdx'
+
 # OpenTelemetry Streaming
 
 <Callout type="info">
@@ -84,16 +86,7 @@ The raw spans sent by Svix can be used in a variety of ways:
 * Storing raw delivery logs for compliance reasons.
 * Much more...
 
-## Support for third-party tools
-
-### Coralogix
-Coralogix OpenTelemetry integration generally works by adding the following custom headers to your OpenTelemetry configuration:
-* CX-Application-Name
-* CX-Subsystem-Name
-
-See [Coralogix OpenTelemetry documentation](https://coralogix.com/docs/opentelemetry/getting-started/) for further details.
-
-For additional instructions on how to integrate your observability provider with OpenTelemetry, please refer to the documentation by your observability provider or [contact Svix support](https://www.svix.com/contact/).
+<OpenTelemetryProviderNotes />
 
 ### Video: Integrating with Grafana Cloud
 This video shows how you can quickly integrate Svix OpenTelemetry exports with Grafana Cloud.

--- a/content/stream/sinks/otel_trace.mdx
+++ b/content/stream/sinks/otel_trace.mdx
@@ -1,6 +1,8 @@
 ---
 title: OpenTelemetry Tracing
 ---
+import OpenTelemetryProviderNotes from '../../_common/otel-provider-notes.mdx'
+
 # OpenTelemetry Tracing
 
 Events can be sent to an OpenTelemetry tracing collector using the `otelTracing` sink type.
@@ -155,7 +157,7 @@ function handler(input) {
 
             // We use the eventType as the name of the span,
             // as it makes it easier to identify which events map to
-            // which spans in Grafana
+            // which spans in your OpenTelemetry platform.
             name: event.eventType,
 
             // We use the msgId as the traceIdKey, to ensure that all spans for the same
@@ -190,6 +192,10 @@ function handler(input) {
 }
 ```
 
-When we send these events to the stream, they'll be dispatched to Grafana. Here, we can see `msg_1234` as its own isolated trace, with the `message.attempt` and `http.attempt` spans correctly grouped together, with the expected attributes.
+When we send these events to the stream, they'll be dispatched to your observability platform.
+
+In this Grafana view, we can see `msg_1234` as its own isolated trace, with the `message.attempt` and `http.attempt` spans correctly grouped together, with the expected attributes.
 
 ![grafana-example](/img/stream/grafana-dashboard.png)
+
+<OpenTelemetryProviderNotes />


### PR DESCRIPTION
Some small updates to the three places we document OpenTelemetry streaming
info. I think it's good to explicitly call out different APM tools here / do it in all places,
so the snippet that does that was moved into a reusable component.

For reference, three places are:
* Dashboard OTEL export configuration
* Advanced endpoint OTEL sink
* Stream OTEL sink

RE https://github.com/svix/monorepo-private/issues/13947