### PR TITLE
Add notes about Datadog OTEL integration

### DIFF
--- a/content/_common/otel-provider-notes.mdx
+++ b/content/_common/otel-provider-notes.mdx
@@ -2,6 +2,13 @@
 
 Most major APM/Observability platforms support OpenTelemetry ingestion with minimal configuration. Depending on the specific tool, you use, you may need to add specific headers in order for ingestion to work correctly.
 
+### Datadog
+Datadog now supports tracing integration via OpenTelemetry natively. In order to set this up, you'll need to know which Datadog site you use and your API key.
+* Datadog's OpenTelemetry URLs are specified as `https://otlp.{SITE}/v1/traces`, e.g., `https://otlp.datadoghq.com/v1/traces` for the `US1` site.
+* `dd-api-key` header must be included and set to a valid API key.
+
+See [Datadog OTLP Intake documentation](https://docs.datadoghq.com/opentelemetry/setup/otlp_ingest/) for more details.
+
 ### Coralogix
 Coralogix OpenTelemetry integration generally works by adding the following custom headers to your OpenTelemetry configuration:
 * `CX-Application-Name` (Should be set to the environment name that produces the data)


### PR DESCRIPTION
Our friends at Datadog have apparently GA'd native OTEL support as of last month. I tested / confirmed this with a new account. So let's add docs about it.

<img width="878" height="317" alt="image" src="https://github.com/user-attachments/assets/8a322755-b893-4212-ae41-65ab605648b1" />
