### PR TITLE
Document Standard Webhooks compliance and header aliases

### DIFF
--- a/content/faq.mdx
+++ b/content/faq.mdx
@@ -72,7 +72,7 @@ Yes! Our webhook service was designed for security from the ground up. We follow
 
 ### Is Svix compliant with the Standard Webhooks specification?
 
-Yes. Svix co-created the [Standard Webhooks](https://www.standardwebhooks.com/) specification and implements it fully. Webhooks are signed as defined in [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), with the `svix-id`, `svix-timestamp`, and `svix-signature` headers as branded aliases of the spec's `webhook-id`, `webhook-timestamp`, and `webhook-signature`. Any Standard Webhooks library can verify Svix webhooks, and the Svix libraries accept either set of header names.
+Yes. Svix co-created the [Standard Webhooks](https://www.standardwebhooks.com/) specification and implements it. Webhooks are signed as defined in [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), with the `svix-id`, `svix-timestamp`, and `svix-signature` headers as branded aliases of the spec's `webhook-id`, `webhook-timestamp`, and `webhook-signature`. Svix webhooks use the spec's HMAC-SHA256 scheme by default, so any Standard Webhooks library can verify them, and the Svix libraries accept either set of header names.
 
 
 ### How to test and debug webhooks?

--- a/content/faq.mdx
+++ b/content/faq.mdx
@@ -70,6 +70,10 @@ Webhooks as a service refers to Svix's software as a service (SaaS) webhook plat
 
 Yes! Our webhook service was designed for security from the ground up. We follow industry best practices, encrypt all data both in transit and at rest, and are compliant with SOC 2 Type II, GDPR, CCPA and more.
 
+### Is Svix compliant with the Standard Webhooks specification?
+
+Yes. Svix co-created the [Standard Webhooks](https://www.standardwebhooks.com/) specification and implements it fully. Webhooks are signed as defined in [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), with the `svix-id`, `svix-timestamp`, and `svix-signature` headers as branded aliases of the spec's `webhook-id`, `webhook-timestamp`, and `webhook-signature`. Any Standard Webhooks library can verify Svix webhooks, and the Svix libraries accept either set of header names.
+
 
 ### How to test and debug webhooks?
 

--- a/content/receiving/verifying-payloads/how.mdx
+++ b/content/receiving/verifying-payloads/how.mdx
@@ -7,6 +7,14 @@ As shown in the [Why Verify section](./why.mdx), verifying operational webhooks 
 
 <ReceivingSkillCallout />
 
+<Callout type="info">
+
+**Standard Webhooks**
+
+Svix implements the [Standard Webhooks](https://www.standardwebhooks.com/) specification, which we co-created. The `svix-id`, `svix-timestamp`, and `svix-signature` headers used below are the Svix-branded aliases of the spec's `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers; the values are identical, and the Svix libraries accept either set of names. This also means any [Standard Webhooks library](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries) can verify Svix webhooks.
+
+</Callout>
+
 ## Verifying using our official libraries
 
 First install the libraries if you haven't already:

--- a/content/receiving/verifying-payloads/why.mdx
+++ b/content/receiving/verifying-payloads/why.mdx
@@ -9,7 +9,7 @@ Because of the way webhooks work, attackers can impersonate services by simply s
 
 In order to prevent it, Svix signs every webhook and its metadata with a unique key for each endpoint. This signature can then be used to verify the webhook indeed comes from Svix, and only process it if it is.
 
-Svix implements the [Standard Webhooks](https://www.standardwebhooks.com/) specification, which we co-created. The signature scheme described here is the one defined in [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), so any Standard Webhooks verification library can verify Svix webhooks.
+Svix implements the [Standard Webhooks](https://www.standardwebhooks.com/) specification, which we co-created. The signature scheme described here is the one defined in [the Standard Webhooks spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), so any Standard Webhooks verification library can verify Svix webhooks.
 
 Another potential security hole is what's called replay attacks. A [replay attack](https://en.wikipedia.org/wiki/Replay_attack) is when an attacker intercepts a valid payload (including the signature), and re-transmits it to your endpoint. This payload will pass signature validation, and will therefore be acted upon.
 

--- a/content/receiving/verifying-payloads/why.mdx
+++ b/content/receiving/verifying-payloads/why.mdx
@@ -9,6 +9,8 @@ Because of the way webhooks work, attackers can impersonate services by simply s
 
 In order to prevent it, Svix signs every webhook and its metadata with a unique key for each endpoint. This signature can then be used to verify the webhook indeed comes from Svix, and only process it if it is.
 
+Svix implements the [Standard Webhooks](https://www.standardwebhooks.com/) specification, which we co-created. The signature scheme described here is the one defined in [the spec](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md), so any Standard Webhooks verification library can verify Svix webhooks.
+
 Another potential security hole is what's called replay attacks. A [replay attack](https://en.wikipedia.org/wiki/Replay_attack) is when an attacker intercepts a valid payload (including the signature), and re-transmits it to your endpoint. This payload will pass signature validation, and will therefore be acted upon.
 
 To mitigate this attack, Svix includes a timestamp for when the webhook attempt occurred. Our libraries automatically reject webhooks with a timestamp that are more than five minutes away (past or future) from the current time. This requires your server's clock to be synchronised and accurate, and it's recommended that you use [NTP](https://en.wikipedia.org/wiki/Network_Time_Protocol) to achieve this.

--- a/content/security.mdx
+++ b/content/security.mdx
@@ -38,7 +38,7 @@ There are a few ways to prevent or reduce the likelihood of spoofing attacks, th
 
 #### Signature verification
 
-When signing the webhooks it's important to sign not only the payload, but also additional metadata such as idempotency ID and timestamp (more on those later). The signature scheme needs to use strong cryptographic primitives and used correctly. Some implementations use asymmetric signing using Ed25519 or RSA, but it's much more common (and recommended) to use `HMAC-SHA256`, which is the scheme the [Standard Webhooks specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md) defines and what Svix uses by default. Svix implements the specification, which we co-created.
+When signing the webhooks it's important to sign not only the payload, but also additional metadata such as idempotency ID and timestamp (more on those later). The signature scheme needs to use strong cryptographic primitives and used correctly. Some implementations use asymmetric signing using Ed25519 or RSA, but it's much more common (and recommended) to use `HMAC-SHA256`, which is what Svix uses by default, following the symmetric scheme defined in the [Standard Webhooks specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md). Svix co-created the specification and implements it.
 
 For more information, please refer to the [webhook verification](/receiving/verifying-payloads/how-manual) docs.
 

--- a/content/security.mdx
+++ b/content/security.mdx
@@ -38,7 +38,7 @@ There are a few ways to prevent or reduce the likelihood of spoofing attacks, th
 
 #### Signature verification
 
-When signing the webhooks it's important to sign not only the payload, but also additional metadata such as idempotency ID and timestamp (more on those later). The signature scheme needs to use strong cryptographic primitives and used correctly. Some implementations use asymmetric signing using Ed25519 or RSA, but it's much more common (and recommended) to use `HMAC-SHA256` which is what Svix uses by default.
+When signing the webhooks it's important to sign not only the payload, but also additional metadata such as idempotency ID and timestamp (more on those later). The signature scheme needs to use strong cryptographic primitives and used correctly. Some implementations use asymmetric signing using Ed25519 or RSA, but it's much more common (and recommended) to use `HMAC-SHA256`, which is the scheme the [Standard Webhooks specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md) defines and what Svix uses by default. Svix implements the specification, which we co-created.
 
 For more information, please refer to the [webhook verification](/receiving/verifying-payloads/how-manual) docs.
 


### PR DESCRIPTION
Adds refs to standard webhooks on the verifying-payloads and security pages, explains the `svix-*` → `webhook-*` header alias mapping (verified against the server's whitelabel_headers behavior and the libraries, which accept both sets), and adds an FAQ entry.