### PR TITLE
Update code samples to SDK v2

### DIFF
--- a/content/event-types.mdx
+++ b/content/event-types.mdx
@@ -1052,7 +1052,7 @@ Once you're ready to release this new event type to all of your users simply rem
 
 ```js
 const svix = new Svix("AUTH_TOKEN");
-await svix.eventType.update("user.signup", { featureFlag: null });
+await svix.eventType.upsert("user.signup", { featureFlag: null });
 ```
 
 </TabItem>
@@ -1060,7 +1060,7 @@ await svix.eventType.update("user.signup", { featureFlag: null });
 
 ```python
 svix = Svix("AUTH_TOKEN")
-svix.event_type.update("user.signup", EventTypeUpdate(feature_flag=None))
+svix.event_type.upsert("user.signup", EventTypeUpsertIn(feature_flag=None))
 ```
 
 </TabItem>
@@ -1070,9 +1070,9 @@ svix.event_type.update("user.signup", EventTypeUpdate(feature_flag=None))
 let svix = Svix::new("AUTH_TOKEN".to_string(), None);
 let event_type_out = svix
     .event_type()
-    .update(
+    .upsert(
         "user.signup".to_string(),
-        EventTypeUpdate {
+        EventTypeUpsertIn {
             feature_flag: None,
             ..Default::default()
         },
@@ -1086,7 +1086,7 @@ let event_type_out = svix
 
 ```go
 svixClient := svix.New("AUTH_TOKEN", nil)
-eventTypeOut, _ := svixClient.EventType.Update(ctx, "user.signup", &svix.EventTypeUpdate{ FeatureFlag: nil })
+eventTypeOut, _ := svixClient.EventType.Upsert(ctx, "user.signup", &svix.EventTypeUpsertIn{ FeatureFlag: nil })
 ```
 
 </TabItem>
@@ -1094,7 +1094,7 @@ eventTypeOut, _ := svixClient.EventType.Update(ctx, "user.signup", &svix.EventTy
 
 ```java
 Svix svix = new Svix("AUTH_TOKEN");
-EventTypeOut eventTypeOut = svix.getEventType().update("user.signup", new EventTypeUpdate()
+EventTypeOut eventTypeOut = svix.getEventType().upsert("user.signup", new EventTypeUpsertIn()
     .featureFlag(null)
 );
 ```
@@ -1104,7 +1104,7 @@ EventTypeOut eventTypeOut = svix.getEventType().update("user.signup", new EventT
 
 ```kotlin
 val svix = Svix("AUTH_TOKEN")
-val eventTypeOut = svix.eventType.update("user.signup", EventTypeUpdate().featureFlag(null))
+val eventTypeOut = svix.eventType.upsert("user.signup", EventTypeUpsertIn().featureFlag(null))
 ```
 
 </TabItem>
@@ -1112,7 +1112,7 @@ val eventTypeOut = svix.eventType.update("user.signup", EventTypeUpdate().featur
 
 ```ruby
 svix = Svix::Client.new("AUTH_TOKEN")
-event_type_out = svix.event_type.update("user.signup", Svix::EventTypeUpdate.new({
+event_type_out = svix.event_type.upsert("user.signup", Svix::EventTypeUpsertIn.new({
     "feature_flag": nil
 }))
 ```
@@ -1122,7 +1122,7 @@ event_type_out = svix.event_type.update("user.signup", Svix::EventTypeUpdate.new
 
 ```csharp
 var svix = new SvixClient("AUTH_TOKEN");
-var eventTypeOut = await svix.EventType.Update("user.signup", new EventTypeUpdate{
+var eventTypeOut = await svix.EventType.Upsert("user.signup", new EventTypeUpsertIn{
     featureFlag: null
 });
 ```
@@ -1134,9 +1134,9 @@ var eventTypeOut = await svix.EventType.Update("user.signup", new EventTypeUpdat
 $svix = new Svix('AUTH_TOKEN');
 
 
-$eventTypeOut = $svix->eventType->update(
+$eventTypeOut = $svix->eventType->upsert(
   'user.signup',
-  EventTypeUpdate::create(description: 'updated description')
+  EventTypeUpsertIn::create(description: 'updated description')
     ->withFeatureFlag(null)
 );
 ```
@@ -1146,7 +1146,7 @@ $eventTypeOut = $svix->eventType->update(
 
 ```shell
 export SVIX_AUTH_TOKEN="AUTH_TOKEN"
-svix event-type update user.signup '{"featureFlag": null}'
+svix event-type upsert user.signup '{"featureFlag": null}'
 ```
 
 </TabItem>

--- a/content/integrations/advanced-zapier.mdx
+++ b/content/integrations/advanced-zapier.mdx
@@ -105,7 +105,7 @@ def get_svix_integration_key():
 
 ### Multiple event types per trigger
 
-If you wish to configure triggers with multiple event types, you can modify the `filterTypes` field on the create endpoint operation during the trigger's subscribe hook.
+If you wish to configure triggers with multiple event types, you can modify the `eventTypes` field on the create endpoint operation during the trigger's subscribe hook.
 
 If you wish your users to specify a set of event types when creating the trigger, you can use Zapier's [input fields](https://platform.zapier.com/cli_docs/docs#input-fields) feature.
 

--- a/content/overview.mdx
+++ b/content/overview.mdx
@@ -30,7 +30,7 @@ Each application lies within its own security context. Each application is compl
 You can define a `uid` for an application which can then be used interchangeably in the API with the application's `id`. Most people set the `uid` to their own internal customer id, so for example if they have a user called `some-user` they would set the `uid` to `some-user` and then use it with the Svix API as follows:
 
 ```javascript
-svix.application.update('some-user', ApplicationIn(/* ... */))
+svix.application.upsert('some-user', ApplicationIn(/* ... */))
 ```
 
 It's recommended to create an application (using the API) for each of their customers when they sign up to your service. You can however also create it "lazily", and only do it when they enable webhooks.

--- a/content/receiving/webhooks-autoconfig.mdx
+++ b/content/receiving/webhooks-autoconfig.mdx
@@ -45,7 +45,7 @@ Call `subscribe()` to complete the configuration.
 import { AutoConfig } from "svix";
 
 const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-  filterTypes: ["invoice.paid", "user.created"],
+  eventTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -62,7 +62,7 @@ webhook = AutoConfig(
     AUTO_CONFIG_TOKEN,
     EndpointIn(
         url="https://api.us.example.com/webhooks/acme",
-        filter_types=["invoice.paid", "user.created"],
+        event_types=["invoice.paid", "user.created"],
     ),
 )
 
@@ -76,7 +76,7 @@ let webhook = svix::AutoConfig::new(
     AUTO_CONFIG_TOKEN.to_string(),
     svix::EndpointIn {
         url: "https://api.us.example.com/webhooks/acme".to_string(),
-        filter_types: Some(vec![
+        event_types: Some(vec![
             "invoice.paid".to_string(),
             "user.created".to_string(),
         ]),
@@ -98,7 +98,7 @@ import (
 
 webhook, err := svix.NewAutoConfig(AUTO_CONFIG_TOKEN, models.EndpointIn{
 	Url:         "https://api.us.example.com/webhooks/acme",
-	FilterTypes: []string{"invoice.paid", "user.created"},
+	EventTypes: []string{"invoice.paid", "user.created"},
 })
 if err != nil {
     panic(err)
@@ -120,7 +120,7 @@ AutoConfig webhook = new AutoConfig(
         AUTO_CONFIG_TOKEN,
         new EndpointIn()
                 .url("https://api.us.example.com/webhooks/acme")
-                .filterTypes(Set.of("invoice.paid", "user.created")));
+                .eventTypes(Set.of("invoice.paid", "user.created")));
 
 webhook.subscribe();
 ```
@@ -135,7 +135,7 @@ val webhook = AutoConfig(
     AUTO_CONFIG_TOKEN,
     EndpointIn(
         url = "https://api.us.example.com/webhooks/acme",
-        filterTypes = setOf("invoice.paid", "user.created"),
+        eventTypes = setOf("invoice.paid", "user.created"),
     ),
 )
 
@@ -149,7 +149,7 @@ require "svix"
 
 endpoint = Svix::EndpointIn.new(
   "url" => "https://api.us.example.com/webhooks/acme",
-  "filterTypes" => ["invoice.paid", "user.created"],
+  "eventTypes" => ["invoice.paid", "user.created"],
 )
 
 webhook = Svix::AutoConfig.new(AUTO_CONFIG_TOKEN, endpoint)
@@ -169,7 +169,7 @@ var webhook = new AutoConfig(
     new EndpointIn
     {
         Url = "https://api.us.example.com/webhooks/acme",
-        FilterTypes = new[] { "invoice.paid", "user.created" },
+        EventTypes = new[] { "invoice.paid", "user.created" },
     });
 
 await webhook.SubscribeAsync();
@@ -184,7 +184,7 @@ use Svix\Models\EndpointIn;
 $webhook = new AutoConfig(
     AUTO_CONFIG_TOKEN,
     EndpointIn::create('https://api.us.example.com/webhooks/acme')
-        ->withFilterTypes(['invoice.paid', 'user.created']),
+        ->withEventTypes(['invoice.paid', 'user.created']),
 );
 
 $webhook->subscribe();
@@ -209,7 +209,7 @@ To verify the payload, call verify() on the same AutoConfig instance you used to
 import { AutoConfig } from "svix";
 
 const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-  filterTypes: ["invoice.paid", "user.created"],
+  eventTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -245,7 +245,7 @@ import { AutoConfig } from "svix";
 const app = express();
 
 const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-  filterTypes: ["invoice.paid", "user.created"],
+  eventTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -265,7 +265,7 @@ For example, in Next.js, you can use [instrumentation](https://nextjs.org/docs/a
 import { AutoConfig } from "svix";
 
 const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-  filterTypes: ["invoice.paid", "user.created"],
+  eventTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 
@@ -295,7 +295,7 @@ jobs:
           import { AutoConfig } from "svix";
 
           const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-            filterTypes: ["invoice.paid", "user.created"],
+            eventTypes: ["invoice.paid", "user.created"],
             url: "https://api.us.example.com/webhooks/acme",
           });
 

--- a/content/webhooks-autoconfig.mdx
+++ b/content/webhooks-autoconfig.mdx
@@ -22,7 +22,7 @@ Here's an example of how this looks like in code:
 import { AutoConfig } from "svix";
 
 const webhook = new AutoConfig(AUTO_CONFIG_TOKEN, {
-  filterTypes: ["invoice.paid", "user.created"],
+  eventTypes: ["invoice.paid", "user.created"],
   url: "https://api.us.example.com/webhooks/acme",
 });
 


### PR DESCRIPTION
A user reported that a code sample is wrong at https://github.com/svix/svix-webhooks/issues/2591, turns out it was just written against SDK v1. We already updated the code samples in the API references but I didn't consider the ones here.