### PR TITLE
Use .to_owned() instead of .to_string() on string literals in Rust code samples

### DIFF
--- a/content/app-portal/index.mdx
+++ b/content/app-portal/index.mdx
@@ -50,11 +50,11 @@ print(dashboard.url)
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let dashboard = svix
     .authentication()
     .app_portal_access(
-        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_owned(),
         AppPortalAccessIn::default(),
         None,
     )

--- a/content/email-notifications.mdx
+++ b/content/email-notifications.mdx
@@ -69,16 +69,16 @@ app = svix.application.create(ApplicationIn(
 ```rust
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let mut metadata = std::collections::HashMap::new();
-metadata.insert("svix.email".to_string(), serde_json::Value::String("example-customer-123@example.com".to_string()));
+metadata.insert("svix.email".to_owned(), serde_json::Value::String("example-customer-123@example.com".to_owned()));
 
 let app = svix
     .application()
     .create(
         ApplicationIn {
-            name: "Example customer 123".to_string(),
-            uid: Some("example-customer-123".to_string()),
+            name: "Example customer 123".to_owned(),
+            uid: Some("example-customer-123".to_owned()),
             metadata: Some(metadata),
             ..ApplicationIn::default()
         },
@@ -266,14 +266,14 @@ svix.application.patch("example-customer-123", {
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let mut metadata = std::collections::HashMap::new();
-metadata.insert("svix.email".to_string(), serde_json::Value::String("example-customer-123@example.com".to_string()));
+metadata.insert("svix.email".to_owned(), serde_json::Value::String("example-customer-123@example.com".to_owned()));
 
 let app = svix
     .application()
     .patch(
-        "example-customer-123".to_string(),
+        "example-customer-123".to_owned(),
         ApplicationPatch {
             metadata: Some(metadata),
             ..ApplicationPatch::default()

--- a/content/event-types.mdx
+++ b/content/event-types.mdx
@@ -74,13 +74,13 @@ app = svix.event_type.create(EventTypeIn(
 <TabItem value="Rust">
 
 ```rust
- let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+ let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
  let event_type = svix
      .event_type()
      .create(
          EventTypeIn {
-             name: "user.signup".to_string(),
-             description: "A user has signed up".to_string(),
+             name: "user.signup".to_owned(),
+             description: "A user has signed up".to_owned(),
              ..EventTypeIn::default()
          },
          None,
@@ -473,7 +473,7 @@ use std::{error::Error, fs::File};
 use svix::api::{EventTypeIn, Svix};
 
 async fn execute() -> Result<(), Box<dyn Error>> {
-    let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+    let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 
     let mut reader = csv::ReaderBuilder::new()
         .delimiter(b'|')
@@ -771,14 +771,14 @@ app = svix.event_type.create(EventTypeIn(
 ```rust
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let event_type = svix
     .event_type()
     .create(
         EventTypeIn {
-            name: "user.signup".to_string(),
-            description: "A user has signed up".to_string(),
-            feature_flags: Some(vec!["beta-feature-a".to_string()]),
+            name: "user.signup".to_owned(),
+            description: "A user has signed up".to_owned(),
+            feature_flags: Some(vec!["beta-feature-a".to_owned()]),
             ..EventTypeIn::default()
         },
         None,
@@ -927,13 +927,13 @@ print(dashboard.url)
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let dashboard = svix
     .authentication()
     .app_portal_access(
-        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_owned(),
         AppPortalAccessIn {
-            feature_flags: Some(vec!["beta-feature-a".to_string()]),
+            feature_flags: Some(vec!["beta-feature-a".to_owned()]),
             ..Default::default()
         },
         None,
@@ -1067,11 +1067,11 @@ svix.event_type.upsert("user.signup", EventTypeUpsertIn(feature_flag=None))
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let event_type_out = svix
     .event_type()
     .upsert(
-        "user.signup".to_string(),
+        "user.signup".to_owned(),
         EventTypeUpsertIn {
             feature_flag: None,
             ..Default::default()

--- a/content/ingest/receiving-with-ingest.mdx
+++ b/content/ingest/receiving-with-ingest.mdx
@@ -63,7 +63,7 @@ Creating a `Source` from the [Ingest Dashboard]:
 <TabItem value="Rust">
 
 ```rust
-  let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+  let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
   let ingest_source_out = svix.ingest().source().create(
       IngestSourceIn {
           name: "myGithubWebhook".to_owned(),

--- a/content/quickstart.mdx
+++ b/content/quickstart.mdx
@@ -210,13 +210,13 @@ app = svix.application.create(ApplicationIn(
 ```rust
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let app = svix
     .application()
     .create(
         ApplicationIn {
-            name: "Application name".to_string(),
-            uid: Some("example-customer-123".to_string()),
+            name: "Application name".to_owned(),
+            uid: Some("example-customer-123".to_owned()),
             ..ApplicationIn::default()
         },
         None,
@@ -382,13 +382,13 @@ svix.message.create(
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 svix.message()
     .create(
-        "example-customer-123".to_string(),
+        "example-customer-123".to_owned(),
         MessageIn {
-            event_type: "invoice.paid".to_string(),
-            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_string()),
+            event_type: "invoice.paid".to_owned(),
+            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_owned()),
             payload: json!({
                 "type": "invoice.paid",
                 "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
@@ -603,13 +603,13 @@ svix.endpoint.create(
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 svix.endpoint()
     .create(
-        "example-customer-123".to_string(),
+        "example-customer-123".to_owned(),
         EndpointIn {
-            url: "https://api.example.com/svix-webhooks/".to_string(),
-            description: Some("My main endpoint".to_string()),
+            url: "https://api.example.com/svix-webhooks/".to_owned(),
+            description: Some("My main endpoint".to_owned()),
             ..EndpointIn::default()
         },
         None,
@@ -761,8 +761,8 @@ svix = SvixAsync("AUTH_TOKEN", SvixOptions(server_url="THE_SERVER_URL"))
 ```rust
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
-let svix = Svix::new("AUTH_TOKEN".to_string(), SvixOptions {
-    server_url: "THE_SERVER_URL".to_string(),
+let svix = Svix::new("AUTH_TOKEN".to_owned(), SvixOptions {
+    server_url: "THE_SERVER_URL".to_owned(),
     ..SvixOptions::default()
 });
 ```

--- a/content/receiving/using-app-portal/polling-endpoints.mdx
+++ b/content/receiving/using-app-portal/polling-endpoints.mdx
@@ -142,8 +142,8 @@ let consumer = svix::AutoConfigConsumer::new(
     AUTO_CONFIG_TOKEN.to_string(),
     svix::SinkInCommon {
         filter_types: Some(vec![
-            "invoice.paid".to_string(),
-            "user.created".to_string(),
+            "invoice.paid".to_owned(),
+            "user.created".to_owned(),
         ]),
         ..Default::default()
     },
@@ -153,10 +153,10 @@ let consumer = svix::AutoConfigConsumer::new(
 consumer.subscribe().await?;
 
 // Inside a worker loop
-let msgs = consumer.receive("my-consumer".to_string(), None).await?;
+let msgs = consumer.receive("my-consumer".to_owned(), None).await?;
 // ... process msgs.data
 let offset = msgs.data.last().unwrap().offset;
-consumer.commit("my-consumer".to_string(), offset, None).await?;
+consumer.commit("my-consumer".to_owned(), offset, None).await?;
 ```
 </TabItem>
 

--- a/content/receiving/verifying-payloads/how.mdx
+++ b/content/receiving/verifying-payloads/how.mdx
@@ -198,7 +198,7 @@ wh.verify(payload, headers)
 ```rust
 use svix::webhooks::Webhook;
 
-let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw".to_string();
+let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw".to_owned();
 
 let mut headers = http::HeaderMap::new();
 headers.insert("svix-id", "msg_p5jXN8AQM9LWM0D4loKWxJek");

--- a/content/receiving/webhooks-autoconfig.mdx
+++ b/content/receiving/webhooks-autoconfig.mdx
@@ -75,10 +75,10 @@ webhook.subscribe()
 let webhook = svix::AutoConfig::new(
     AUTO_CONFIG_TOKEN.to_string(),
     svix::EndpointIn {
-        url: "https://api.us.example.com/webhooks/acme".to_string(),
+        url: "https://api.us.example.com/webhooks/acme".to_owned(),
         event_types: Some(vec![
-            "invoice.paid".to_string(),
-            "user.created".to_string(),
+            "invoice.paid".to_owned(),
+            "user.created".to_owned(),
         ]),
         ..Default::default()
     },

--- a/content/retention.mdx
+++ b/content/retention.mdx
@@ -72,13 +72,13 @@ svixClient.Message.Create(ctx, "app_Xzx8bQeOB1D1XEYmAJaRGoj0", &svix.MessageIn{
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 svix.message()
     .create(
-        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_string(),
+        "app_Xzx8bQeOB1D1XEYmAJaRGoj0".to_owned(),
         MessageIn {
-            event_type: "invoice.paid".to_string(),
-            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_string()),
+            event_type: "invoice.paid".to_owned(),
+            event_id: Some("evt_Wqb1k73rXprtTm7Qdlr38G".to_owned()),
             payload: json!({
                 "id": "invoice_WF7WtCLFFtd8ubcTgboSFNql",
                 "status": "paid",

--- a/content/stream/event-types/introduction.mdx
+++ b/content/stream/event-types/introduction.mdx
@@ -43,14 +43,14 @@ stream_event_type_out = svix.streaming.event_type.create(StreamEventTypeIn(
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let stream_event_type_out = svix
     .streaming()
     .event_type()
     .create(StreamEventTypeIn {
-        name: "user.signup".to_string(),
+        name: "user.signup".to_owned(),
         description: None,
-        feature_flags: Some(vec!["cool-new-feature".to_string()]),
+        feature_flags: Some(vec!["cool-new-feature".to_owned()]),
     }, None)
     .await?;
 ```

--- a/content/stream/introduction.mdx
+++ b/content/stream/introduction.mdx
@@ -43,15 +43,15 @@ stream_out = svix.streaming.stream.create(StreamIn(
 <TabItem value="Rust">
 
 ```rust
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 
 let stream_out = svix
     .streaming()
     .stream()
     .create(
         StreamIn {
-            name: "My Stream".to_string(),
-            uid: Some("unique-identifier".to_string()),
+            name: "My Stream".to_owned(),
+            uid: Some("unique-identifier".to_owned()),
         },
         None
     ).await?;

--- a/content/throttling.mdx
+++ b/content/throttling.mdx
@@ -51,12 +51,12 @@ app = svix.application.create(ApplicationIn(name="Application name", throttle_ra
 ```rust
 use svix::api::{ApplicationIn, Svix, SvixOptions};
 
-let svix = Svix::new("AUTH_TOKEN".to_string(), None);
+let svix = Svix::new("AUTH_TOKEN".to_owned(), None);
 let app = svix
     .application()
     .create(
         ApplicationIn {
-            name: "Application name".to_string(),
+            name: "Application name".to_owned(),
             throttle_rate: Some(1000),
             ..ApplicationIn::default()
         },


### PR DESCRIPTION
Matching our own code style. `.to_string()` isn't *that* bad, but `.to_owned()` is IMHO clearer, and anybody pasting this into a code base that also uses the `clippy::str_to_string` lint would get warnings w/o this change.